### PR TITLE
Add an example fetching and parsing a page

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ you may query (with a browser, or `curl` and friends):
 * `http://localhost:6927/_info/version`
 * `http://localhost:6927/_info/home`
 * `http://localhost:6927/v1/siteinfo/{uri}{/prop}`
+* `http://localhost:6927/v1/page/{title}`
+* `http://localhost:6927/v1/page/{title}/lead`
 
 ## Tests
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "bluebird": "^2.9.9",
     "body-parser": "^1.12.0",
     "compression": "^1.4.1",
+    "domino": "^1.0.18",
     "express": "^4.11.2",
     "js-yaml": "^3.2.6",
     "multer": "^0.1.7",

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -4,6 +4,7 @@
 var BBPromise = require('bluebird');
 var express = require('express');
 var preq = require('preq');
+var domino = require('domino');
 
 
 /**
@@ -76,6 +77,77 @@ router.get('/siteinfo/:uri/:prop?', function(req, res) {
         res.status(200).json(apiRes.body.query.general);
     });
 
+});
+
+
+/****************************
+ *  PAGE MASSAGING SECTION  *
+ ****************************/
+
+/**
+ * A helper function that obtains the HTML form enwiki and
+ * loads it into a domino DOM document instance.
+ *
+ * @param {String} title the title of the page to get
+ * @return {Promise} a promise resolving as the HTML element object
+ */
+function getBody(title) {
+
+    // get the page from enwiki
+    return preq.get({
+        uri: 'http://en.wikipedia.org/w/index.php',
+        qs: {
+            title: title
+        },
+        useQuerystring: true
+    }).then(function(callRes) {
+        // and then load and parse the page
+        return domino.createDocument(callRes.body);
+    });
+
+}
+
+
+/**
+ * GET /page/{title}
+ * Gets the body of a given enwiki page.
+ */
+router.get('/page/:title', function(req, res) {
+    // get the page's HTML directly
+    return getBody(req.params.title)
+    // and then return it
+    .then(function(doc) {
+        res.status(200).type('html').end(doc.body.innerHTML);
+    });
+});
+
+
+/**
+ * GET /page/{title}/lead
+ * Gets the leading section of a given enwiki page.
+ */
+router.get('/page/:title/lead', function(req, res) {
+    // get the page's HTML directly
+    return getBody(req.params.title)
+    // and then find the leading section and return it
+    .then(function(doc) {
+        var leadSec = '';
+        // get the content div
+        var content = doc.getElementById('mw-content-text');
+        // find all paragraphs in it
+        var ps = content && content.querySelectorAll('p') || [];
+        for(var idx = 0; idx < ps.length; idx++) {
+            var child = ps[idx];
+            // find the first paragraph that is not empty
+            if(!/^\s*$/.test(child.innerHTML) ) {
+                // that must be our leading section
+                // so enclose it in a <div>
+                leadSec = '<div id="lead_section">' + child.innerHTML + '</div>';
+                break;
+            }
+        }
+        res.status(200).type('html').end(leadSec);
+    });
 });
 
 

--- a/test/features/v1/page.js
+++ b/test/features/v1/page.js
@@ -1,0 +1,61 @@
+'use strict';
+
+
+// mocha defines to avoid JSHint breakage
+/* global describe, it, before, beforeEach, after, afterEach */
+
+
+var preq   = require('preq');
+var assert = require('../../utils/assert.js');
+var server = require('../../utils/server.js');
+
+
+describe('page gets', function() {
+
+    this.timeout(20000);
+
+    before(function () { return server.start(); });
+
+    // common URI prefix for the page
+    var uri = server.config.uri + 'v1/page/Mulholland%20Drive%20%28film%29/';
+
+    it('should get the whole page body', function() {
+        return preq.get({
+            uri: uri
+        }).then(function(res) {
+            // check the status
+            assert.status(res, 200);
+            // check the returned Content-Type header
+            assert.contentType(res, 'text/html');
+            // inspect the body
+            assert.notDeepEqual(res.body, undefined, 'No body returned!');
+            // this should be the right page
+            if(!/<\s*?h1.+Mulholland/.test(res.body)) {
+                throw new Error('Not the title I was expecting!');
+            }
+        });
+    });
+
+    it('should get only the leading section', function() {
+        return preq.get({
+            uri: uri + 'lead'
+        }).then(function(res) {
+            // check the status
+            assert.status(res, 200);
+            // check the returned Content-Type header
+            assert.contentType(res, 'text/html');
+            // inspect the body
+            assert.notDeepEqual(res.body, undefined, 'No body returned!');
+            // this should be the right page
+            if(!/Mulholland/.test(res.body)) {
+                throw new Error('Not the page I was expecting!');
+            }
+            // .. and should start with <div id="lead_section">
+            if(!/^<div id="lead_section">/.test(res.body)) {
+                throw new Error('This is not a leading section!');
+            }
+        });
+    });
+
+});
+


### PR DESCRIPTION
This simple example route fetches an article from enWiki and parses it using domino to extract the leading section.
