### PR TITLE
Adds /robots.txt - no indexing rule

### DIFF
--- a/routes/root.js
+++ b/routes/root.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var router = require('express').Router();
+
+/**
+ * GET /robots.txt
+ * no indexing
+ */
+router.get('/robots.txt', function(req, res) {
+    res.end( 'User-agent: *\nDisallow: /\n' );
+});
+
+module.exports = function(appObj) {
+
+    return {
+        path: '/',
+        router: router
+    };
+
+};


### PR DESCRIPTION
Most services should not be indexed unless specifically designed,
so adding a simple root.js - where people could add other routes.
