### PR TITLE
Update service-runner dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "js-yaml": "^3.2.6",
     "multer": "^0.1.7",
     "preq": "^0.3.9",
-    "service-runner": "^0.0.2"
+    "service-runner": "^0.1.3"
   },
   "devDependencies": {
     "assert": "^1.3.0",


### PR DESCRIPTION
We didn't update the service-runner version in a while, and `^0.0.2` won't update to `0.1.x` by default.
