### PR TITLE
Remove the multer module

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,7 +6,6 @@ var BBPromise = require('bluebird');
 var express = require('express');
 var compression = require('compression');
 var bodyParser = require('body-parser');
-var multer = require('multer');
 var fs = BBPromise.promisifyAll(require('fs'));
 var sUtil = require('./lib/util');
 var packageInfo = require('./package.json');
@@ -43,8 +42,6 @@ function initApp(options) {
     app.use(bodyParser.json());
     // use the application/x-www-form-urlencoded parser
     app.use(bodyParser.urlencoded({extended: true}));
-    // use the multipart/form-data
-    app.use(multer());
     // serve static files from static/
     app.use('/static', express.static(__dirname + '/static'));
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "domino": "^1.0.18",
     "express": "^4.11.2",
     "js-yaml": "^3.2.6",
-    "multer": "^0.1.7",
     "preq": "^0.3.9",
     "service-runner": "^0.1.3"
   },


### PR DESCRIPTION
With the advent of RESTBase acting as the proxy for other services, no direct file uploads are envisioned, so disable that feature completely from the template. We can always add a good solution at a later time if/when needed.

Bug: [T90408](https://phabricator.wikimedia.org/T90408)
