### PR TITLE
Add the domain to the URI layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ you may query (with a browser, or `curl` and friends):
 * `http://localhost:6927/_info/name`
 * `http://localhost:6927/_info/version`
 * `http://localhost:6927/_info/home`
-* `http://localhost:6927/v1/siteinfo/{uri}{/prop}`
-* `http://localhost:6927/v1/page/{title}`
-* `http://localhost:6927/v1/page/{title}/lead`
+* `http://localhost:6927/{domain}/v1/siteinfo{/prop}`
+* `http://localhost:6927/{domain}/v1/page/{title}`
+* `http://localhost:6927/{domain}/v1/page/{title}/lead`
 * `http://localhost:6927/ex/err/array`
 * `http://localhost:6927/ex/err/file`
 * `http://localhost:6927/ex/err/manual/error`

--- a/app.js
+++ b/app.js
@@ -72,13 +72,18 @@ function loadRoutes (app) {
         var route = require(__dirname + '/routes/' + fname);
         route = route(app);
         // check that the route exports the object we need
-        if (route.constructor !== Object || !route.path || !route.router) {
+        if (route.constructor !== Object || !route.path || !route.router || !(route.api_version || route.skip_domain)) {
             throw new TypeError('routes/' + fname + ' does not export the correct object!');
         }
         // wrap the route handlers with Promise.try() blocks
         sUtil.wrapRouteHandlers(route.router);
+        // determine the path prefix
+        var prefix = '';
+        if(!route.skip_domain) {
+            prefix = '/:domain/v' + route.api_version;
+        }
         // all good, use that route
-        app.use(route.path, route.router);
+        app.use(prefix + route.path, route.router);
     }).then(function () {
         // catch errors
         sUtil.setErrorHandler(app);

--- a/lib/util.js
+++ b/lib/util.js
@@ -3,6 +3,7 @@
 
 var BBPromise = require('bluebird');
 var util = require('util');
+var express = require('express');
 
 
 /**
@@ -138,9 +139,33 @@ function setErrorHandler(app) {
 }
 
 
+/**
+ * Creates a new router with some default options.
+ *
+ * @param {Object} opts additional options to pass to express.Router()
+ * @return {Router} a new router object
+ */
+function createRouter(opts) {
+
+    var options = {
+        mergeParams: true
+    };
+
+    if(opts && opts.constructor === Object) {
+        Object.keys(opts).forEach(function(key) {
+            options[key] = opts[key];
+        });
+    }
+
+    return express.Router(options);
+
+}
+
+
 module.exports = {
     HTTPError: HTTPError,
     wrapRouteHandlers: wrapRouteHandlers,
-    setErrorHandler: setErrorHandler
+    setErrorHandler: setErrorHandler,
+    router: createRouter
 };
 

--- a/routes/empty.js.template
+++ b/routes/empty.js.template
@@ -2,7 +2,6 @@
 
 
 var BBPromise = require('bluebird');
-var express = require('express');
 var preq = require('preq');
 var sUtil = require('../lib/util');
 
@@ -13,7 +12,7 @@ var HTTPError = sUtil.HTTPError;
 /**
  * The main router object
  */
-var router = express.Router();
+var router = sUtil.router();
 
 /**
  * The main application object reported when this module is require()d
@@ -28,8 +27,11 @@ module.exports = function(appObj) {
 
     app = appObj;
 
+    // the returned object mounts the routes on
+    // /{domain}/vX/mount/path
     return {
-        path: '/full/path/to/mount/routes/to',
+        path: '/mount/path',
+        api_version: X,  // must be a number!
         router: router
     };
 

--- a/routes/ex.js
+++ b/routes/ex.js
@@ -2,7 +2,6 @@
 
 
 var BBPromise = require('bluebird');
-var express = require('express');
 var preq = require('preq');
 var sUtil = require('../lib/util');
 var fs = BBPromise.promisifyAll(require('fs'));
@@ -14,7 +13,7 @@ var HTTPError = sUtil.HTTPError;
 /**
  * The main router object
  */
-var router = express.Router();
+var router = sUtil.router();
 
 /**
  * The main application object reported when this module is require()d
@@ -125,6 +124,7 @@ module.exports = function(appObj) {
 
     return {
         path: '/ex',
+        skip_domain: true,
         router: router
     };
 

--- a/routes/info.js
+++ b/routes/info.js
@@ -1,13 +1,13 @@
 'use strict';
 
 
-var express = require('express');
+var sUtil = require('../lib/util');
 
 
 /**
  * The main router object
  */
-var router = express.Router();
+var router = sUtil.router();
 
 /**
  * The main application object reported when this module is require()d
@@ -82,6 +82,7 @@ module.exports = function(appObj) {
 
     return {
         path: '/_info',
+        skip_domain: true,
         router: router
     };
 

--- a/routes/root.js
+++ b/routes/root.js
@@ -1,13 +1,13 @@
 'use strict';
 
 
-var express = require('express');
+var sUtil = require('../lib/util');
 
 
 /**
  * The main router object
  */
-var router = express.Router();
+var router = sUtil.router();
 
 
 /**
@@ -28,6 +28,7 @@ module.exports = function(appObj) {
 
     return {
         path: '/',
+        skip_domain: true,
         router: router
     };
 

--- a/test/features/ex/errors.js
+++ b/test/features/ex/errors.js
@@ -75,7 +75,7 @@ describe('errors', function() {
         });
     });
 
-    it('access denied error', function() {
+    it('authorisation error', function() {
         return preq.get({
             uri: uri + 'manual/auth'
         }).then(function(res) {

--- a/test/features/v1/page.js
+++ b/test/features/v1/page.js
@@ -17,7 +17,7 @@ describe('page gets', function() {
     before(function () { return server.start(); });
 
     // common URI prefix for the page
-    var uri = server.config.uri + 'v1/page/Mulholland%20Drive%20%28film%29/';
+    var uri = server.config.uri + 'en.wikipedia.org/v1/page/Mulholland%20Drive%20%28film%29/';
 
     it('should get the whole page body', function() {
         return preq.get({
@@ -59,7 +59,7 @@ describe('page gets', function() {
 
     it('should throw a 404 for a non-existent page', function() {
         return preq.get({
-            uri: server.config.uri + 'v1/page/Foobar_and_friends'
+            uri: server.config.uri + 'en.wikipedia.org/v1/page/Foobar_and_friends'
         }).then(function(res) {
             // if we are here, no error was thrown, not good
             throw new Error('Expected an error to be thrown, got status: ', res.status);

--- a/test/features/v1/siteinfo.js
+++ b/test/features/v1/siteinfo.js
@@ -17,7 +17,7 @@ describe('wiki site info', function() {
     before(function () { return server.start(); });
 
     // common URI prefix for v1
-    var uri = server.config.uri + 'v1/siteinfo/en.wikipedia.org/';
+    var uri = server.config.uri + 'en.wikipedia.org/v1/siteinfo/';
 
     it('should get all general enwiki site info', function() {
         return preq.get({
@@ -58,7 +58,7 @@ describe('wiki site info', function() {
 
     it('should fail to get info from a non-existent wiki', function() {
         return preq.get({
-            uri: server.config.uri + 'v1/siteinfo/non.existent.wiki'
+            uri: server.config.uri + 'non.existent.wiki/v1/siteinfo/'
         }).then(function(res) {
             // if we are here, no error was thrown, not good
             throw new Error('Expected an error to be thrown, got status: ', res.status);


### PR DESCRIPTION
This PR adds the `domain` parameter to the URI layout and enforces route versioning. More specifically, route modules are now required to return the following object when `require()`d:

``` javascript
{
  path: '/mount-path',
  api_version: 1,
  router: router
}
```

When imported, the routes handled by the `router` object are going to be mounted at `/{domain}/v1/mount-path`. Naturally, routes will have access to the domain through the `req.params.domain` request parameter.

Bug: [T90631](https://phabricator.wikimedia.org/T90631)
