### PR TITLE
Set request IDs and use them for logging

### DIFF
--- a/app.js
+++ b/app.js
@@ -28,9 +28,9 @@ function initApp(options) {
     app.info = packageInfo;         // this app's package info
 
     // ensure some sane defaults
-    if (!app.conf.port) { app.conf.port = 8888; }
-    if (!app.conf.interface) { app.conf.interface = '0.0.0.0'; }
-    if (!app.conf.compression_level) { app.conf.compression_level = 3; }
+    if(!app.conf.port) { app.conf.port = 8888; }
+    if(!app.conf.interface) { app.conf.interface = '0.0.0.0'; }
+    if(!app.conf.compression_level) { app.conf.compression_level = 3; }
 
     // disable the X-Powered-By header
     app.set('x-powered-by', false);
@@ -62,18 +62,18 @@ function loadRoutes (app) {
     .map(function (fname) {
         // ... and then load each route
         // but only if it's a js file
-        if (!/\.js$/.test(fname)) {
+        if(!/\.js$/.test(fname)) {
             return;
         }
         // import the route file
         var route = require(__dirname + '/routes/' + fname);
         route = route(app);
         // check that the route exports the object we need
-        if (route.constructor !== Object || !route.path || !route.router || !(route.api_version || route.skip_domain)) {
+        if(route.constructor !== Object || !route.path || !route.router || !(route.api_version || route.skip_domain)) {
             throw new TypeError('routes/' + fname + ' does not export the correct object!');
         }
         // wrap the route handlers with Promise.try() blocks
-        sUtil.wrapRouteHandlers(route.router);
+        sUtil.wrapRouteHandlers(route.router, app);
         // determine the path prefix
         var prefix = '';
         if(!route.skip_domain) {

--- a/config.dev.yaml
+++ b/config.dev.yaml
@@ -18,9 +18,9 @@ logging:
 
 # Statsd metrics reporter
 metrics:
-  type: txstatsd
-  host: localhost
-  port: 8125
+  type: log
+  #host: localhost
+  #port: 8125
 
 services:
   - name: service-template-node

--- a/doc/coding.md
+++ b/doc/coding.md
@@ -181,11 +181,11 @@ creating / throwing the error.
 
 Logging and metrics collection is supported out of the box via
 [service-runner](https://github.com/wikimedia/service-runner). They are exposed
-in route handler files via the `app.logger` and `app.metrics` objects.
+in route handler files via the `req.logger` and `app.metrics` objects.
 
 ### Logging
 
-To log something, simply use `app.logger.log(level, what)`. The logger itself is
+To log something, simply use `req.logger.log(level, what)`. The logger itself is
 a [bunyan](https://github.com/trentm/node-bunyan) wrapper, and thus supports the
 following levels:
 
@@ -213,7 +213,7 @@ router.get('/:name/about', function(req, res) {
             + encodeURIComponent(req.params.name) + '.html'
     };
 
-    app.logger.log('debug/people/about', info);
+    req.logger.log('debug/people/about', info);
 
     return fs.readFileAsync(info.path)
     .then(function(src) {
@@ -229,6 +229,12 @@ router.get('/:name/about', function(req, res) {
 
 });
 ```
+
+As you can see, the request object (`req`) has an additional property -
+`req.logger`, which allows you to log messages and objects in the context of the
+current request. To do so, it attaches a unique *request ID* to each logged
+information. If you would like to log context-free information, you can use the
+`app.logger` object instead, even though that is not recommended.
 
 ### Metrics Collection
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -4,6 +4,8 @@
 var BBPromise = require('bluebird');
 var util = require('util');
 var express = require('express');
+var uuid = require('node-uuid');
+var bunyan = require('bunyan');
 
 
 /**
@@ -41,20 +43,79 @@ util.inherits(HTTPError, Error);
 
 
 /**
+ * Generates an object suitable for logging out of a request object
+ *
+ * @param {Request} the request
+ * @return {Object} an object containing the key components of the request
+ */
+function reqForLog(req) {
+
+    return {
+        url: req.originalUrl,
+        headers: req.headers,
+        method: req.method,
+        params: req.params,
+        query: req.query,
+        body: req.body,
+        remoteAddress: req.connection.remoteAddress,
+        remotePort: req.connection.remotePort
+    };
+
+}
+
+
+/**
+ * Serialises an error object in a form suitable for logging
+ *
+ * @param {Error} the error to serialise
+ * @return {Object} the serialised version of the error
+ */
+function errForLog(err) {
+
+    var ret = bunyan.stdSerializers.err(err);
+    ret.status = err.status;
+    ret.type = err.type;
+    ret.detail = err.detail;
+
+    return ret;
+
+}
+
+/**
+ * Generates a unique request ID
+ *
+ * @return {String} the generated request ID
+ */
+var reqIdBuff = new Buffer(16);
+function generateRequestId() {
+
+    uuid.v4(null, reqIdBuff);
+    return reqIdBuff.toString('hex');
+
+}
+
+
+
+/**
  * Wraps all of the given router's handler functions with
  * promised try blocks so as to allow catching all errors,
  * regardless of whether a handler returns/uses promises
  * or not.
  *
  * @param {Router} the router object
+ * @param {Application} the application object
  */
-function wrapRouteHandlers(router) {
+function wrapRouteHandlers(router, app) {
 
     router.stack.forEach(function(routerLayer) {
         routerLayer.route.stack.forEach(function(layer) {
             var origHandler = layer.handle;
             layer.handle = function(req, res, next) {
                 BBPromise.try(function() {
+                    req.headers = req.headers || {};
+                    req.headers['x-request-id'] = req.headers['x-request-id'] || generateRequestId();
+                    req.logger = app.logger.child({request_id: req.headers['x-request-id']});
+                    req.logger.log('trace/req', {req: reqForLog(req), msg: 'incoming request'});
                     return origHandler(req, res, next);
                 })
                 .catch(next);

--- a/lib/util.js
+++ b/lib/util.js
@@ -182,9 +182,17 @@ function setErrorHandler(app) {
         if(!errObj.uri) { errObj.uri = req.url; }
         // some set 'message' or 'description' instead of 'detail'
         errObj.detail = errObj.detail || errObj.message || errObj.description || '';
+        // adjust the log level based on the status code
+        var level = 'error';
+        if(Number.parseInt(errObj.status) < 400) {
+            level = 'trace';
+        } else if(Number.parseInt(errObj.status) < 500) {
+            level = 'info';
+        }
         // log the error
-        app.logger.log('error/' + app.info.name +
-                (errObj.component ? '/' + errObj.component : '/' + err.status), errObj);
+        req.logger.log(level +
+                (errObj.component ? '/' + errObj.component : '/' + errObj.status),
+                errForLog(errObj));
         // let through only non-sensitive info
         var respBody = {
             status: errObj.status,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-template-node",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A blueprint for MediaWiki REST API services",
   "main": "./app.js",
   "scripts": {
@@ -22,28 +22,28 @@
     "MediaWiki"
   ],
   "author": "Wikimedia Service Team <services@wikimedia.org>",
-  "contributors": [
-  ],
+  "contributors": [],
   "license": "Apache2",
   "bugs": {
     "url": "https://phabricator.wikimedia.org/tag/services/"
   },
   "homepage": "https://github.com/wikimedia/service-template-node",
   "dependencies": {
-    "bluebird": "^2.9.9",
-    "body-parser": "^1.12.0",
-    "compression": "^1.4.1",
+    "bluebird": "^2.9.14",
+    "body-parser": "^1.12.1",
+    "bunyan": "^1.3.4",
+    "compression": "^1.4.3",
     "domino": "^1.0.18",
-    "express": "^4.11.2",
-    "js-yaml": "^3.2.6",
-    "preq": "^0.3.9",
-    "service-runner": "^0.1.3"
+    "express": "^4.12.2",
+    "js-yaml": "^3.2.7",
+    "node-uuid": "^1.4.3",
+    "preq": "^0.3.12",
+    "service-runner": "^0.1.4"
   },
   "devDependencies": {
     "assert": "^1.3.0",
-    "bunyan": "^1.3.4",
-    "istanbul": "^0.3.6",
-    "mocha": "^2.1.0",
+    "istanbul": "^0.3.8",
+    "mocha": "^2.2.1",
     "mocha-jshint": "0.0.9",
     "mocha-lcov-reporter": "0.0.1"
   }

--- a/test/utils/logStream.js
+++ b/test/utils/logStream.js
@@ -2,7 +2,7 @@
 
 var bunyan = require('bunyan');
 
-function logStream() {
+function logStream(logStdout) {
 
   var log = [];
   var parrot = bunyan.createLogger({
@@ -14,7 +14,7 @@ function logStream() {
     try {
         var entry = JSON.parse(chunk);
         var levelMatch = /^(\w+)/.exec(entry.levelPath);
-        if (levelMatch) {
+        if (logStdout && levelMatch) {
             var level = levelMatch[1];
             if (parrot[level]) {
                 parrot[level](entry);


### PR DESCRIPTION
In order to be able to reconstruct all of the events associated with a particular request, the template now supports the `X-Request-Id` header. If it is not set for incoming requests, it is automatically generated. Additionally, a `logger` property is now being attached to request objects allowing logging information within the context of the current request (tracked via the request ID).

Also:
- log all incoming requests
- improve error logging
- improve the testing logger stream
- update package versions of dependencies
- bump the package version
