### PR TITLE
Add init script templates and a generator script

### DIFF
--- a/dist/init-scripts/systemd.erb
+++ b/dist/init-scripts/systemd.erb
@@ -1,0 +1,25 @@
+[Unit]
+Description=<%= @description ? @service_name + ' - ' + @description : @service_name %>
+Documentation=<%= @homepage %>
+After=network.target local-fs.target
+
+[Service]
+Type=simple
+LimitNOFILE=10000
+PIDFile=%t/<%= @service_name %>.pid
+User=<%= @service_name %>
+Group=<%= @service_name %>
+WorkingDirectory=/srv/deployment/<%= @service_name %>/deploy
+Environment="NODE_PATH='/srv/deployment/<%= @service_name %>/deploy/node_modules'" "<%= @service_name.gsub(/[^a-z0-9_]/, '_').upcase %>_PORT=<%= @port %>"
+ExecStart=/usr/bin/nodejs src/server.js -c /etc/<%= @service_name %>/config.yaml
+Restart=always
+RestartSec=5
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=<%= @service_name %>
+TimeoutStartSec=5
+TimeoutStopSec=60
+
+[Install]
+WantedBy=multi-user.target
+

--- a/dist/init-scripts/sysvinit.erb
+++ b/dist/init-scripts/sysvinit.erb
@@ -1,0 +1,171 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          <%= @service_name %>
+# Required-Start:    $local_fs $network $remote_fs $syslog
+# Required-Stop:     $local_fs $network $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: <%= @description || @service_name %>
+# Description:       <%= @description ? @service_name + ' - ' + @description : @service_name %>
+### END INIT INFO
+
+
+# PATH should only include /usr/* if it runs after the mountnfs.sh script
+PATH=/sbin:/usr/sbin:/bin:/usr/bin
+DESC="<%= @service_name %> service"
+NAME=<%= @service_name %>
+SCRIPT_PATH=/srv/deployment/<%= @service_name %>/deploy/src/server.js
+DAEMON="/usr/bin/nodejs $SCRIPT_PATH"
+DAEMON_ARGS="-c /etc/<%= @service_name %>/config.yaml"
+PIDFILE=/var/run/$NAME.pid
+SCRIPTNAME=/etc/init.d/$NAME
+
+# Exit if the package is not installed
+[ -e "$SCRIPT_PATH" ] || exit 0
+
+# Read configuration variable file if it is present
+[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
+# export some variables into the process' environment
+export PORT
+export INTERFACE
+export NODE_PATH='/srv/deployment/<%= @service_name %>/deploy/node_modules'
+export <%= @service_name.gsub(/[^a-z0-9_]/, '_').upcase %>_PORT=<%= @port %>
+
+
+# Load the VERBOSE setting and other rcS variables
+. /lib/init/vars.sh
+
+# Define LSB log_* functions.
+# Depend on lsb-base (>= 3.2-14) to ensure that this file is present
+# and status_of_proc is working.
+. /lib/lsb/init-functions
+
+#
+# Function that starts the daemon/service
+#
+do_start()
+{
+	# up the number of fds [sockets] from 1024
+	ulimit -n 10000
+
+	# Return
+	#   0 if daemon has been started
+	#   1 if daemon was already running
+	#   2 if daemon could not be started
+
+	start-stop-daemon --start --quiet --pidfile $PIDFILE -bm \
+		-c <%= @service_name %>:<%= @service_name %> --test \
+                --exec /bin/sh -- \
+                -c "$DAEMON $DAEMON_ARGS 2>&1 | logger -i -t <%= @service_name %>" \
+		|| return 1
+	start-stop-daemon --start --quiet --pidfile $PIDFILE -bm \
+		-c <%= @service_name %>:<%= @service_name %> \
+                --exec /bin/sh -- \
+                -c "$DAEMON $DAEMON_ARGS 2>&1 | logger -i -t <%= @service_name %>" \
+		|| return 2
+	echo "Started <%= @service_name %> service on port <%= @port %>"
+
+
+	# Add code here, if necessary, that waits for the process to be ready
+	# to handle requests from services started subsequently which depend
+	# on this one.  As a last resort, sleep for some time.
+	sleep 5
+}
+
+#
+# Function that stops the daemon/service
+#
+do_stop()
+{
+	# Return
+	#   0 if daemon has been stopped
+	#   1 if daemon was already stopped
+	#   2 if daemon could not be stopped
+	#   other if a failure occurred
+	start-stop-daemon --stop --quiet --retry=TERM/60/KILL/5 --pidfile $PIDFILE --name $NAME
+	RETVAL="$?"
+	[ "$RETVAL" = 2 ] && return 2
+	# Wait for children to finish too if this is a daemon that forks
+	# and if the daemon is only ever run from this initscript.
+	# If the above conditions are not satisfied then add some other code
+	# that waits for the process to drop all resources that could be
+	# needed by services started subsequently.  A last resort is to
+	# sleep for some time.
+	start-stop-daemon --stop --quiet --oknodo --retry=0/5/KILL/5 --exec $DAEMON
+	[ "$?" = 2 ] && return 2
+	# Many daemons don't delete their pidfiles when they exit.
+	rm -f $PIDFILE
+	return "$RETVAL"
+}
+
+#
+# Function that sends a SIGHUP to the daemon/service
+#
+do_reload() {
+	#
+	# If the daemon can reload its configuration without
+	# restarting (for example, when it is sent a SIGHUP),
+	# then implement that here.
+	#
+	start-stop-daemon --stop --signal 1 --quiet --pidfile $PIDFILE --name $NAME
+	return 0
+}
+
+case "$1" in
+  start)
+	[ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
+	do_start
+	case "$?" in
+		0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+		2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+	esac
+	;;
+  stop)
+	[ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
+	do_stop
+	case "$?" in
+		0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+		2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+	esac
+	;;
+  status)
+	status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
+	;;
+  #reload|force-reload)
+	#
+	# If do_reload() is not implemented then leave this commented out
+	# and leave 'force-reload' as an alias for 'restart'.
+	#
+	#log_daemon_msg "Reloading $DESC" "$NAME"
+	#do_reload
+	#log_end_msg $?
+	#;;
+  restart|force-reload)
+	#
+	# If the "reload" option is implemented then remove the
+	# 'force-reload' alias
+	#
+	log_daemon_msg "Restarting $DESC" "$NAME"
+	do_stop
+	case "$?" in
+	  0|1)
+		do_start
+		case "$?" in
+			0) log_end_msg 0 ;;
+			1) log_end_msg 1 ;; # Old process is still running
+			*) log_end_msg 1 ;; # Failed to start
+		esac
+		;;
+	  *)
+		# Failed to stop
+		log_end_msg 1
+		;;
+	esac
+	;;
+  *)
+	echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload}" >&2
+	exit 3
+	;;
+esac
+

--- a/dist/init-scripts/upstart.erb
+++ b/dist/init-scripts/upstart.erb
@@ -1,0 +1,24 @@
+# Upstart job for <%= @service_name %>
+
+description "<%= @description ? @service_name + ' - ' + @description : @service_name %>"
+
+start on (local-filesystems and net-device-up IFACE!=lo)
+stop on runlevel [!2345]
+
+# up ulimit -n a bit
+limit nofile 10000 10000
+
+setuid "<%= @service_name %>"
+setgid "<%= @service_name %>"
+
+env NODE_PATH="/srv/deployment/<%= @service_name %>/deploy/node_modules"
+env <%= @service_name.gsub(/[^a-zA-Z0-9_]/, '_').upcase %>_PORT="<%= @port %>"
+
+respawn
+
+# wait 60 seconds for a graceful restart before killing the master
+kill timeout 60
+
+chdir /srv/deployment/<%= @service_name %>/deploy
+exec /usr/bin/nodejs src/server.js -c /etc/<%= @service_name %>/config.yaml >> /var/log/<%= @service_name %>/main.log 2>&1
+

--- a/scripts/gen-init-scripts.rb
+++ b/scripts/gen-init-scripts.rb
@@ -1,0 +1,70 @@
+#!/usr/bin/env ruby
+
+
+require 'erb'
+require 'json'
+require 'yaml'
+
+
+rootdir = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+indir = File.join(rootdir, 'dist', 'init-scripts')
+outdir = indir
+
+
+class ScriptData
+
+  include ERB::Util
+
+  @@suffix = {'systemd' => '.service', 'upstart' => '.conf'}
+  
+  def initialize input_dir
+    @template = {}
+    self.init input_dir
+  end
+
+  def set_info root_dir
+    self.read_info(root_dir).each do |key, value|
+      self.instance_variable_set "@#{key}".to_sym, value
+    end
+    @service_name = @name
+  end
+
+  def generate output_dir
+    @template.each do |name, erb|
+      File.open(File.join(output_dir, "#{@name}#{@@suffix[name]}"), 'w') do |io|
+        io.write erb.result(binding())
+      end
+    end
+  end
+
+  def init input_dir
+    Dir.glob(File.join(input_dir, '*.erb')).each do |fname|
+      @template[File.basename(fname, '.erb')] = ERB.new(File.read(fname))
+    end
+  end
+
+  def read_info root_dir
+    data = YAML.load(File.read(File.join(root_dir, 'config.yaml')))['services'][0]['conf']
+    return data.merge(JSON.load(File.read(File.join(root_dir, 'package.json'))))
+  end
+
+end
+
+
+if ARGV.size > 0 and ['-h', '--help'].include? ARGV[0]
+  puts 'This is a simple script to generate various service init scripts'
+  puts 'Usage: gen-init-scripts.rb [output_dir]'
+  exit 1
+elsif ARGV.size > 0
+  outdir = ARGV[0]
+end
+
+unless File.directory? outdir
+  STDERR.puts 'The output directory must exist! Aborting...'
+  exit 2
+end
+
+data = ScriptData.new indir
+data.set_info rootdir
+data.generate outdir
+


### PR DESCRIPTION
Three init scripts are provided, for SystemD, SysV and Upstart, respectively. They all assume the service is to be run from its deploy repository located under the `/srv/deployment/` directory, with the configuration file `/etc/service-name/config.yaml`.

These templates should primarily be used as companions to the service's Puppet module. A convenience script, `scripts/gen-init-scripts.rb`, is provided as well in case the user wants to generate them directly.
