### PR TITLE
Use `app.logger` as an alternative to `req.logger`

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -190,7 +190,7 @@ function setErrorHandler(app) {
             level = 'info';
         }
         // log the error
-        req.logger.log(level + '/' +
+        (req.logger || app.logger).log(level + '/' +
                 (errObj.component ? errObj.component : errObj.status),
                 errForLog(errObj));
         // let through only non-sensitive info


### PR DESCRIPTION
`req.logger` is only available after the wrapper has been executed. That
means that if errors are raised before the wrapped route is reached
(such as executing other middleware) `req.logger` is not available.
Thus, provide `app.logger` as an alternative which is always available.
