### PR TITLE
Swagger spec for monitoring

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,6 +9,7 @@ var bodyParser = require('body-parser');
 var fs = BBPromise.promisifyAll(require('fs'));
 var sUtil = require('./lib/util');
 var packageInfo = require('./package.json');
+var yaml = require('js-yaml');
 
 
 /**
@@ -49,6 +50,31 @@ function initApp(options) {
                 process.env.NO_PROXY = app.conf.no_proxy_list;
             }
         }
+    }
+
+    // set up the spec
+    if(!app.conf.spec) {
+        app.conf.spec = __dirname + '/spec.yaml';
+    }
+    try {
+        app.conf.spec = yaml.safeLoad(fs.readFileSync(app.conf.spec));
+    } catch(e) {
+        app.logger.log('warn/spec', 'Could not load the spec: ' + e);
+        app.conf.spec = {};
+    }
+    if(!app.conf.spec.swagger) {
+        app.conf.spec.swagger = '2.0';
+    }
+    if(!app.conf.spec.info) {
+        app.conf.spec.info = {
+            version: app.info.version,
+            title: app.info.name,
+            description: app.info.description
+        };
+    }
+    app.conf.spec.info.version = app.info.version;
+    if(!app.conf.spec.paths) {
+        app.conf.spec.paths = {};
     }
 
     // set the CORS and CSP headers

--- a/config.dev.yaml
+++ b/config.dev.yaml
@@ -33,6 +33,8 @@ services:
       port: 6927
       # interface: localhost # uncomment to only listen on localhost
       # more per-service config settings
+      # the location of the spec, defaults to spec.yaml if not specified
+      spec: ./spec.template.yaml
       # allow cross-domain requests to the API (default '*')
       cors: '*'
       # to disable use:

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "express": "^4.12.4",
     "js-yaml": "^3.3.1",
     "node-uuid": "^1.4.3",
-    "preq": "^0.4.1",
+    "preq": "^0.4.3",
     "service-runner": "^0.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "istanbul": "^0.3.13",
     "mocha": "^2.2.4",
     "mocha-jshint": "0.0.9",
-    "mocha-lcov-reporter": "0.0.1"
+    "mocha-lcov-reporter": "0.0.1",
+    "swagger-router": "^0.1.0"
   },
   "deploy": {
     "target": "ubuntu",

--- a/package.json
+++ b/package.json
@@ -28,23 +28,22 @@
   },
   "homepage": "https://github.com/wikimedia/service-template-node",
   "dependencies": {
-    "bluebird": "^2.9.24",
-    "body-parser": "^1.12.3",
-    "bunyan": "^1.3.5",
-    "compression": "^1.4.3",
+    "bluebird": "^2.9.27",
+    "body-parser": "^1.12.4",
+    "bunyan": "^1.3.6",
+    "compression": "^1.4.4",
     "domino": "^1.0.18",
-    "express": "^4.12.3",
-    "js-yaml": "^3.2.7",
+    "express": "^4.12.4",
+    "js-yaml": "^3.3.1",
     "node-uuid": "^1.4.3",
-    "preq": "^0.3.13",
-    "service-runner": "^0.1.8"
+    "preq": "^0.4.1",
+    "service-runner": "^0.2.0"
   },
   "devDependencies": {
-    "assert": "^1.3.0",
-    "istanbul": "^0.3.13",
+    "istanbul": "^0.3.14",
     "mocha": "^2.2.4",
-    "mocha-jshint": "0.0.9",
-    "mocha-lcov-reporter": "0.0.1",
+    "mocha-jshint": "^2.2.3",
+    "mocha-lcov-reporter": "^0.0.2",
     "swagger-router": "^0.1.0"
   },
   "deploy": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-template-node",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "A blueprint for MediaWiki REST API services",
   "main": "./app.js",
   "scripts": {

--- a/routes/root.js
+++ b/routes/root.js
@@ -9,6 +9,11 @@ var sUtil = require('../lib/util');
  */
 var router = sUtil.router();
 
+/**
+ * The main application object reported when this module is require()d
+ */
+var app;
+
 
 /**
  * GET /robots.txt
@@ -24,7 +29,20 @@ router.get('/robots.txt', function(req, res) {
 });
 
 
+/**
+ * GET /_spec
+ * Retrieves the service's specification JSON
+ */
+router.get('/_spec', function(req, res) {
+
+    res.json(app.conf.spec);
+
+});
+
+
 module.exports = function(appObj) {
+
+    app = appObj;
 
     return {
         path: '/',

--- a/routes/root.js
+++ b/routes/root.js
@@ -30,12 +30,17 @@ router.get('/robots.txt', function(req, res) {
 
 
 /**
- * GET /_spec
- * Retrieves the service's specification JSON
+ * GET /
+ * Main entry point. Currently it only responds if the spec query
+ * parameter is given, otherwise lets the next middleware handle it
  */
-router.get('/_spec', function(req, res) {
+router.get('/', function(req, res, next) {
 
-    res.json(app.conf.spec);
+    if(!(req.query || {}).hasOwnProperty('spec')) {
+        next();
+    } else {
+        res.json(app.conf.spec);
+    }
 
 });
 

--- a/spec.template.yaml
+++ b/spec.template.yaml
@@ -1,6 +1,6 @@
 swagger: '2.0'
 info:
-  version: 0.1.3
+  version: 0.2.0
   title: WMF Node.JS Service Template
   description: A template for creating Node.JS services
   termsOfService: https://wikimediafoundation.org/wiki/Terms_of_Use

--- a/spec.template.yaml
+++ b/spec.template.yaml
@@ -59,7 +59,7 @@ paths:
             params:
               domain: my.fake.domain
           response:
-            status: 500
+            status: 504
             headers:
               content-type: application/json
         - title: site info check for valid prop

--- a/spec.template.yaml
+++ b/spec.template.yaml
@@ -28,15 +28,30 @@ paths:
             headers:
               user-agent: '*'
               disallow: '/'
-  /_spec:
+  /:
     get:
       tags:
         - Root
-        - Spec
-      description: Gets the specification of the service
+      description: The root service end-point
       produces:
         - application/json
-      x-monitor: false
+      x-amples:
+        - title: root with no query params
+          request: {}
+          response:
+            status: 404
+        - title: spec from root
+          request:
+            query:
+              spec: true
+          response:
+            status: 200
+        - title: root with wrong query param
+          request:
+            query:
+              fooo: true
+          response:
+            status: 404
   # from routes/v1.js
   /{domain}/v1/siteinfo{/prop}:
     get:

--- a/spec.template.yaml
+++ b/spec.template.yaml
@@ -1,0 +1,265 @@
+swagger: '2.0'
+info:
+  version: 0.1.3
+  title: WMF Node.JS Service Template
+  description: A template for creating Node.JS services
+  termsOfService: https://wikimediafoundation.org/wiki/Terms_of_Use
+  contact:
+    name: the Wikimedia Services team
+    url: http://mediawiki.org/wiki/Services
+  license:
+    name: Apache2
+    url: http://www.apache.org/licenses/LICENSE-2.0
+x-default-params:
+  domain: en.wikipedia.org
+paths:
+  # from routes/root.js
+  /robots.txt:
+    get:
+      tags:
+        - Root
+        - Robots
+      description: Gets robots.txt
+      x-amples:
+        - title: robots.txt check
+          request: {}
+          response:
+            status: 200
+            headers:
+              user-agent: '*'
+              disallow: '/'
+  /_spec:
+    get:
+      tags:
+        - Root
+        - Spec
+      description: Gets the specification of the service
+      produces:
+        - application/json
+      x-monitor: false
+  # from routes/v1.js
+  /{domain}/v1/siteinfo{/prop}:
+    get:
+      tags:
+        - Site info
+        - MW API call
+        - Example
+      description: Calls the MW API siteinfo action and returns the response
+      produces:
+        - application/json
+      x-amples:
+        - title: site info for default domain
+          request: {}
+          response:
+            status: 200
+            headers:
+              content-type: application/json
+        - title: site info for a non-existent domain
+          request:
+            params:
+              domain: my.fake.domain
+          response:
+            status: 500
+            headers:
+              content-type: application/json
+        - title: site info check for valid prop
+          request:
+            params:
+              prop: sitename
+          response:
+            status: 200
+            headers:
+              content-type: application/json
+            body:
+              sitename: Wikipedia
+        - title: site info check for invalid prop
+          request:
+            params:
+              prop: blaprop
+          response:
+            status: 404
+            headers:
+              content-type: application/json
+  /{domain}/v1/page/{title}:
+    get:
+      tags:
+        - Page content
+        - Example
+      description: Gets the HTML for the page with the given title
+      produces:
+        - text/html
+        - application/json
+      x-amples:
+        - title: get the Foobar page from en.wp.org
+          request:
+            params:
+              title: Foobar
+          response:
+            status: 200
+            headers:
+              content-type: text/html
+  /{domain}/v1/page/{title}/lead:
+    get:
+      tags:
+        - Page content
+        - Lead section
+        - Example
+      description: Gets the lead-section HTML for the page with the given title
+      produces:
+        - text/html
+        - application/json
+      x-amples:
+        - title: get the lead section for Barack Obama
+          request:
+            params:
+              title: Barack Obama
+          response:
+            status: 200
+            headers:
+              content-type: text/html
+  # from routes/info.js
+  /_info:
+    get:
+      tags:
+        - Service information
+      description: Gets information about the service
+      produces:
+        - application/json
+      x-amples:
+        - title: retrieve service info
+          request: {}
+          response:
+            status: 200
+            headers:
+              content-type: application/json
+            body:
+              name: /.+/
+              description: /.+/
+              version: /.+/
+              home: /.+/
+  /_info/name:
+    get:
+      tags:
+        - Service information
+        - Service name
+      description: Gets the name of the service
+      produces:
+        - application/json
+      x-amples:
+        - title: retrieve service name
+          request: {}
+          response:
+            status: 200
+            headers:
+              content-type: application/json
+            body:
+              name: /.+/
+  /_info/version:
+    get:
+      tags:
+        - Service information
+        - Service version
+      description: Gets the running version of the service
+      produces:
+        - application/json
+      x-amples:
+        - title: retrieve service version
+          request: {}
+          response:
+            status: 200
+            headers:
+              content-type: application/json
+            body:
+              version: /.+/
+  /_info/home:
+    get:
+      tags:
+        - Service information
+        - Service homepage
+      description: Redirects to the home page
+      x-amples:
+        - title: redirect to the home page
+          request: {}
+          response:
+            status: 301
+  # from routes/ex.js
+  /ex/err/array:
+    get:
+      tags:
+        - Example
+        - Error
+        - Internal error
+      description: Generates an internal error due to a wrong array declaration
+      produces:
+        - application/json
+      x-amples:
+        - title: wrong array declaration example
+          request: {}
+          response:
+            status: 500
+            headers:
+              content-type: application/json
+  /ex/err/file:
+    get:
+      tags:
+        - Example
+        - Error
+        - Internal error
+      description: Generates an internal error due to a non-existing file
+      produces:
+        - application/json
+      x-amples:
+        - title: non-existing file example
+          request: {}
+          response:
+            status: 500
+            headers:
+              content-type: application/json
+  /ex/err/manual/error:
+    get:
+      tags:
+        - Example
+        - Error
+        - Internal error
+      description: Generates an internal error due to a user-thrown error
+      produces:
+        - application/json
+      x-amples:
+        - title: user error example
+          request: {}
+          response:
+            status: 500
+            headers:
+              content-type: application/json
+  /ex/err/manual/deny:
+    get:
+      tags:
+        - Example
+        - Error
+        - Access denied
+      description: Generates an access-denied error
+      produces:
+        - application/json
+      x-amples:
+        - title: access denied error example
+          request: {}
+          response:
+            status: 403
+            headers:
+              content-type: application/json
+  /ex/err/manual/auth:
+    get:
+      tags:
+        - Example
+        - Error
+        - Unauthorised access
+      description: Generates an unauthorised error
+      produces:
+        - application/json
+      x-amples:
+        - title: unauthorised error example
+          request: {}
+          response:
+            status: 401
+            headers:
+              content-type: application/json

--- a/test/features/app/spec.js
+++ b/test/features/app/spec.js
@@ -1,0 +1,252 @@
+'use strict';
+
+
+var preq   = require('preq');
+var assert = require('../../utils/assert.js');
+var server = require('../../utils/server.js');
+var URI    = require('swagger-router').URI;
+var yaml   = require('js-yaml');
+var fs     = require('fs');
+
+
+function staticSpecLoad() {
+
+    var spec;
+    var myService = server.config.conf.services[server.config.conf.services.length - 1].conf;
+    var specPath = __dirname + '/../../../' + (myService.spec ? myService.spec : 'spec.yaml');
+
+    try {
+        spec = yaml.safeLoad(fs.readFileSync(specPath));
+    } catch(e) {
+        // this error will be detected later, so ignore it
+        spec = {paths: {}, 'x-default-params': {}};
+    }
+
+    return spec;
+
+}
+
+
+function validateExamples(pathStr, defParams, mSpec) {
+
+    var uri = new URI(pathStr, {}, true);
+
+    if(!mSpec) {
+        try {
+            uri.expand(defParams);
+            return true;
+        } catch(e) {
+            throw new Error('Missing parameter for route ' + pathStr + ' : ' + e.message);
+        }
+    }
+
+    if(!Array.isArray(mSpec)) {
+        throw new Error('Route ' + pathStr + ' : x-amples must be an array!');
+    }
+
+    mSpec.forEach(function(ex, idx) {
+        if(!ex.title) {
+            throw new Error('Route ' + pathStr + ', example ' + idx + ': title missing!');
+        }
+        ex.request = ex.request || {};
+        try {
+            uri.expand(Object.assign({}, defParams, ex.request.params || {}));
+        } catch(e) {
+            throw new Error('Route ' + pathStr + ', example ' + idx + ' (' + ex.title + '): missing parameter: ' + e.message);
+        }
+    });
+
+    return true;
+
+}
+
+
+function constructTestCase(title, path, method, request, response) {
+
+    return {
+        title: title,
+        request: {
+            uri: server.config.uri + (path[0] === '/' ? path.substr(1) : path),
+            method: method,
+            headers: request.headers || {},
+            query: request.query,
+            body: request.body,
+            followRedirect: false
+        },
+        response: {
+            status: response.status || 200,
+            headers: response.headers || {},
+            body: response.body
+        }
+    };
+
+}
+
+
+function constructTests(paths, defParams) {
+
+    var ret = [];
+
+    Object.keys(paths).forEach(function(pathStr) {
+        Object.keys(paths[pathStr]).forEach(function(method) {
+            var p = paths[pathStr][method];
+            var uri;
+            if(p.hasOwnProperty('x-monitor') && !p['x-monitor']) {
+                return;
+            }
+            uri = new URI(pathStr, {}, true);
+            if(!p['x-amples']) {
+                ret.push(constructTestCase(
+                    pathStr,
+                    uri.toString({params: defParams}),
+                    method,
+                    {},
+                    {}
+                ));
+                return;
+            }
+            p['x-amples'].forEach(function(ex) {
+                ex.request = ex.request || {};
+                ret.push(constructTestCase(
+                    ex.title,
+                    uri.toString({params: Object.assign({}, defParams, ex.request.params || {})}),
+                    method,
+                    ex.request,
+                    ex.response || {}
+                ));
+            });
+        });
+    });
+
+    return ret;
+
+}
+
+
+function cmp(result, expected, errMsg) {
+
+    expected = expected || '';
+    result = result || '';
+
+    if(expected.length > 1 && expected[0] === '/' && expected[expected.length - 1] === '/') {
+        if((new RegExp(expected.slice(1, -1))).test(result)) {
+            return true;
+        }
+    } else if(expected.length === 0 && result.length === 0) {
+        return true;
+    } else if(result === expected || result.startsWith(expected)) {
+        return true;
+    }
+
+    assert.deepEqual(result, expected, errMsg);
+    return true;
+
+}
+
+
+function validateTestResponse(testCase, res) {
+
+    var expRes = testCase.response;
+
+    // check the status
+    assert.status(res, expRes.status);
+    // check the headers
+    Object.keys(expRes.headers).forEach(function(key) {
+        var val = expRes.headers[key];
+        assert.deepEqual(res.headers.hasOwnProperty(key), true, 'Header ' + key + ' not found in response!');
+        cmp(res.headers[key], val, key + ' header mismatch!');
+    });
+    // check the body
+    if(!expRes.body) {
+        return true;
+    }
+    res.body = res.body || '';
+    if(Buffer.isBuffer(res.body)) { res.body = res.body.toString(); }
+    if(expRes.body.constructor !== res.body.constructor) {
+        if(expRes.body.constructor === String) {
+            res.body = JSON.stringify(res.body);
+        } else {
+            res.body = JSON.parse(res.body);
+        }
+    }
+    if(expRes.body.constructor === Object) {
+        Object.keys(expRes.body).forEach(function(key) {
+            var val = expRes.body[key];
+            assert.deepEqual(res.body.hasOwnProperty(key), true, 'Body field ' + key + ' not found in response!');
+            cmp(res.body[key], val, key + ' body field mismatch!');
+        });
+    } else {
+        cmp(res.body, expRes.body, 'Body mismatch!');
+    }
+
+    return true;
+
+}
+
+
+describe('Swagger spec', function() {
+
+    // the variable holding the spec
+    var spec = staticSpecLoad();
+    // default params, if given
+    var defParams = spec['x-default-params'] || {};
+
+    this.timeout(20000);
+
+    before(function () {
+        return server.start();
+    });
+
+    it('get the spec', function() {
+        return preq.get(server.config.uri + '_spec')
+        .then(function(res) {
+            assert.status(200);
+            assert.contentType(res, 'application/json');
+            assert.notDeepEqual(res.body, undefined, 'No body received!');
+            spec = res.body;
+        });
+    });
+
+    it('spec validation', function() {
+        if(spec['x-default-params']) {
+            defParams = spec['x-default-params'];
+        }
+        // check the high-level attributes
+        ['info', 'swagger', 'paths'].forEach(function(prop) {
+            assert.deepEqual(!!spec[prop], true, 'No ' + prop + ' field present!');
+        });
+        // no paths - no love
+        assert.deepEqual(!!Object.keys(spec.paths), true, 'No paths given in the spec!');
+        // now check each path
+        Object.keys(spec.paths).forEach(function(pathStr) {
+            var path;
+            assert.deepEqual(!!pathStr, true, 'A path cannot have a length of zero!');
+            path = spec.paths[pathStr];
+            assert.deepEqual(!!Object.keys(path), true, 'No methods defined for path: ' + pathStr);
+            Object.keys(path).forEach(function(method) {
+                var mSpec = path[method];
+                if(mSpec.hasOwnProperty('x-monitor') && !mSpec['x-monitor']) {
+                    return;
+                }
+                validateExamples(pathStr, defParams, mSpec['x-amples']);
+            });
+        });
+    });
+
+    describe('routes', function() {
+
+        constructTests(spec.paths, defParams).forEach(function(testCase) {
+            it(testCase.title, function() {
+                return preq(testCase.request)
+                .then(function(res) {
+                    validateTestResponse(testCase, res);
+                }, function(err) {
+                    validateTestResponse(testCase, err);
+                });
+            });
+        });
+
+    });
+
+});
+

--- a/test/features/app/spec.js
+++ b/test/features/app/spec.js
@@ -198,7 +198,7 @@ describe('Swagger spec', function() {
     });
 
     it('get the spec', function() {
-        return preq.get(server.config.uri + '_spec')
+        return preq.get(server.config.uri + '?spec')
         .then(function(res) {
             assert.status(200);
             assert.contentType(res, 'application/json');

--- a/test/features/v1/siteinfo.js
+++ b/test/features/v1/siteinfo.js
@@ -67,7 +67,7 @@ describe('wiki site info', function() {
             throw new Error('Expected an error to be thrown, got status: ' + res.status);
         }, function(err) {
             // inspect the status
-            assert.deepEqual(err.status, 500);
+            assert.deepEqual(err.status, 504);
         });
     });
 


### PR DESCRIPTION
This PR introduces the Swagger specification for routes, with the intent of it being used for automatic-monitoring purposes. Services based on this template now expose the `/?spec` end-point which delivers it.

The test suite has been enhanced to validate entirely the specification and test each route and their examples, thus ensuring no false positives occur in production during monitoring.

Bug: [T94833](https://phabricator.wikimedia.org/T94833)
