### PR TITLE
Minor spec testing and dependency changes

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -4,7 +4,7 @@
 var BBPromise = require('bluebird');
 var util = require('util');
 var express = require('express');
-var uuid = require('node-uuid');
+var uuid = require('cassandra-uuid');
 var bunyan = require('bunyan');
 
 
@@ -86,11 +86,9 @@ function errForLog(err) {
  *
  * @return {String} the generated request ID
  */
-var reqIdBuff = new Buffer(16);
 function generateRequestId() {
 
-    uuid.v4(null, reqIdBuff);
-    return reqIdBuff.toString('hex');
+    return uuid.TimeUuid.now().toString();
 
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-template-node",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A blueprint for MediaWiki REST API services",
   "main": "./app.js",
   "scripts": {
@@ -28,23 +28,23 @@
   },
   "homepage": "https://github.com/wikimedia/service-template-node",
   "dependencies": {
-    "bluebird": "^2.9.27",
-    "body-parser": "^1.12.4",
-    "bunyan": "^1.3.6",
-    "compression": "^1.4.4",
+    "bluebird": "~2.8.2",
+    "body-parser": "^1.13.2",
+    "bunyan": "^1.4.0",
+    "cassandra-uuid": "^0.0.2",
+    "compression": "^1.5.1",
     "domino": "^1.0.18",
-    "express": "^4.12.4",
+    "express": "^4.13.1",
     "js-yaml": "^3.3.1",
-    "node-uuid": "^1.4.3",
-    "preq": "^0.4.3",
-    "service-runner": "^0.2.0"
+    "preq": "^0.4.4",
+    "service-runner": "^0.2.1"
   },
   "devDependencies": {
-    "istanbul": "^0.3.14",
-    "mocha": "^2.2.4",
+    "istanbul": "^0.3.17",
+    "mocha": "^2.2.5",
     "mocha-jshint": "^2.2.3",
     "mocha-lcov-reporter": "^0.0.2",
-    "swagger-router": "^0.1.0"
+    "swagger-router": "^0.1.1"
   },
   "deploy": {
     "target": "ubuntu",

--- a/spec.template.yaml
+++ b/spec.template.yaml
@@ -1,6 +1,6 @@
 swagger: '2.0'
 info:
-  version: 0.2.0
+  version: 0.2.1
   title: WMF Node.JS Service Template
   description: A template for creating Node.JS services
   termsOfService: https://wikimediafoundation.org/wiki/Terms_of_Use


### PR DESCRIPTION
- Allow recursive checks of the response body in `test/features/app/spec.js`
- Downgrade `bluebird` to v2.8.2
- Upgrade most module versions
- Replace `node-uuid` with `cassandra-uuid` to get rid of the binary dependency
