### PR TITLE
Provide an SPDX-compatible licence name

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "author": "Wikimedia Service Team <services@wikimedia.org>",
   "contributors": [],
-  "license": "Apache2",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://phabricator.wikimedia.org/tag/service-template-node/"
   },


### PR DESCRIPTION
The [SPDX licence list](http://spdx.org/licenses/) lists our licence as _Apache-2.0_.

Bug: [T107700](https://phabricator.wikimedia.org/T107700)
