### PR TITLE
Return server instance to service-runner

### DIFF
--- a/app.js
+++ b/app.js
@@ -56,11 +56,13 @@ function initApp(options) {
     if(!app.conf.spec) {
         app.conf.spec = __dirname + '/spec.yaml';
     }
-    try {
-        app.conf.spec = yaml.safeLoad(fs.readFileSync(app.conf.spec));
-    } catch(e) {
-        app.logger.log('warn/spec', 'Could not load the spec: ' + e);
-        app.conf.spec = {};
+    if(app.conf.spec.constructor !== Object) {
+        try {
+            app.conf.spec = yaml.safeLoad(fs.readFileSync(app.conf.spec));
+        } catch(e) {
+            app.logger.log('warn/spec', 'Could not load the spec: ' + e);
+            app.conf.spec = {};
+        }
     }
     if(!app.conf.spec.swagger) {
         app.conf.spec.swagger = '2.0';
@@ -160,8 +162,9 @@ function createServer(app) {
     // return a promise which creates an HTTP server,
     // attaches the app to it, and starts accepting
     // incoming client requests
+    var server;
     return new BBPromise(function (resolve) {
-        http.createServer(app).listen(
+        server = http.createServer(app).listen(
             app.conf.port,
             app.conf.interface,
             resolve
@@ -169,6 +172,7 @@ function createServer(app) {
     }).then(function () {
         app.logger.log('info',
             'Worker ' + process.pid + ' listening on ' + app.conf.interface + ':' + app.conf.port);
+        return server;
     });
 
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "service-runner": "^0.2.1"
   },
   "devDependencies": {
+    "extend": "^3.0.0",
     "istanbul": "^0.3.17",
     "mocha": "^2.2.5",
     "mocha-jshint": "^2.2.3",

--- a/test/utils/server.js
+++ b/test/utils/server.js
@@ -8,9 +8,10 @@
 var BBPromise = require('bluebird');
 var ServiceRunner = require('service-runner');
 var logStream = require('./logStream');
-var fs        = require('fs');
-var assert    = require('./assert');
-var yaml      = require('js-yaml');
+var fs = require('fs');
+var assert = require('./assert');
+var yaml = require('js-yaml');
+var extend = require('extend');
 
 
 // set up the configuration
@@ -19,7 +20,8 @@ var config = {
 };
 // build the API endpoint URI by supposing the actual service
 // is the last one in the 'services' list in the config file
-var myService = config.conf.services[config.conf.services.length - 1];
+var myServiceIdx = config.conf.services.length - 1;
+var myService = config.conf.services[myServiceIdx];
 config.uri = 'http://localhost:' + myService.conf.port + '/';
 // no forking, run just one process when testing
 config.conf.num_workers = 0;
@@ -29,8 +31,10 @@ config.conf.logging = {
     level: 'trace',
     stream: logStream()
 };
+// make a deep copy of it for later reference
+var origConfig = extend(true, {}, config);
 
-var stop    = function () {};
+var stop = function () {};
 var options = null;
 var runner = new ServiceRunner();
 
@@ -43,6 +47,9 @@ function start(_options) {
         console.log('server options changed; restarting');
         stop();
         options = _options;
+        // set up the config
+        config = extend(true, {}, origConfig);
+        extend(true, config.conf.services[myServiceIdx].conf, options);
         return runner.run(config.conf)
         .then(function(servers) {
             var server = servers[0];


### PR DESCRIPTION
`service-runner` stores the server instance returned by the loaded module for reference. However, the template did not return anything to it.

This PR also improves the test suite, as it allows for proper and clean restarts during testing.

Bug: [T107763](https://phabricator.wikimedia.org/T107763)
