### PR TITLE
Async route loading, better req logging wrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 Dockerfile
+.idea/
 coverage
 config.yaml
 node_modules

--- a/app.js
+++ b/app.js
@@ -91,6 +91,9 @@ function initApp(options) {
         res.header('Content-Security-Policy', app.conf.csp);
         res.header('X-Content-Security-Policy', app.conf.csp);
         res.header('X-WebKit-CSP', app.conf.csp);
+
+        sUtil.initAndLogRequest(req, app);
+
         next();
     });
 
@@ -121,35 +124,40 @@ function loadRoutes (app) {
 
     // get the list of files in routes/
     return fs.readdirAsync(__dirname + '/routes')
-    .map(function (fname) {
-        // ... and then load each route
-        // but only if it's a js file
-        if(!/\.js$/.test(fname)) {
-            return;
-        }
-        // import the route file
-        var route = require(__dirname + '/routes/' + fname);
-        route = route(app);
-        // check that the route exports the object we need
-        if(route.constructor !== Object || !route.path || !route.router || !(route.api_version || route.skip_domain)) {
-            throw new TypeError('routes/' + fname + ' does not export the correct object!');
-        }
-        // wrap the route handlers with Promise.try() blocks
-        sUtil.wrapRouteHandlers(route.router, app);
-        // determine the path prefix
-        var prefix = '';
-        if(!route.skip_domain) {
-            prefix = '/:domain/v' + route.api_version;
-        }
-        // all good, use that route
-        app.use(prefix + route.path, route.router);
-    }).then(function () {
-        // catch errors
-        sUtil.setErrorHandler(app);
-        // route loading is now complete, return the app object
-        return BBPromise.resolve(app);
-    });
-
+        .map(function (fname) {
+            return BBPromise.try(function () {
+                // ... and then load each route
+                // but only if it's a js file
+                if(!/\.js$/.test(fname)) {
+                    return undefined;
+                }
+                // import the route file
+                var route = require(__dirname + '/routes/' + fname);
+                return route(app);
+            }).then(function (route) {
+                if(route === undefined) {
+                    return undefined;
+                }
+                // check that the route exports the object we need
+                if (route.constructor !== Object || !route.path || !route.router || !(route.api_version || route.skip_domain)) {
+                    throw new TypeError('routes/' + fname + ' does not export the correct object!');
+                }
+                // wrap the route handlers with Promise.try() blocks
+                sUtil.wrapRouteHandlers(route.router);
+                // determine the path prefix
+                var prefix = '';
+                if(!route.skip_domain) {
+                    prefix = '/:domain/v' + route.api_version;
+                }
+                // all good, use that route
+                app.use(prefix + route.path, route.router);
+            });
+        }).then(function () {
+            // catch errors
+            sUtil.setErrorHandler(app);
+            // route loading is now complete, return the app object
+            return BBPromise.resolve(app);
+        });
 }
 
 /**

--- a/lib/util.js
+++ b/lib/util.js
@@ -45,7 +45,7 @@ util.inherits(HTTPError, Error);
 /**
  * Generates an object suitable for logging out of a request object
  *
- * @param {Request} the request
+ * @param {Request} req request
  * @return {Object} an object containing the key components of the request
  */
 function reqForLog(req) {
@@ -67,7 +67,7 @@ function reqForLog(req) {
 /**
  * Serialises an error object in a form suitable for logging
  *
- * @param {Error} the error to serialise
+ * @param {Error} err error to serialise
  * @return {Object} the serialised version of the error
  */
 function errForLog(err) {
@@ -99,20 +99,15 @@ function generateRequestId() {
  * regardless of whether a handler returns/uses promises
  * or not.
  *
- * @param {Router} the router object
- * @param {Application} the application object
+ * @param {Router} router object
  */
-function wrapRouteHandlers(router, app) {
+function wrapRouteHandlers(router) {
 
     router.stack.forEach(function(routerLayer) {
         routerLayer.route.stack.forEach(function(layer) {
             var origHandler = layer.handle;
             layer.handle = function(req, res, next) {
                 BBPromise.try(function() {
-                    req.headers = req.headers || {};
-                    req.headers['x-request-id'] = req.headers['x-request-id'] || generateRequestId();
-                    req.logger = app.logger.child({request_id: req.headers['x-request-id']});
-                    req.logger.log('trace/req', {req: reqForLog(req), msg: 'incoming request'});
                     return origHandler(req, res, next);
                 })
                 .catch(next);
@@ -228,8 +223,23 @@ function createRouter(opts) {
 }
 
 
+/**
+ * Adds logger to the request and logs it
+ *
+ * @param {*} req request object
+ * @param {Application} app application object
+ */
+function initAndLogRequest(req, app) {
+    req.headers = req.headers || {};
+    req.headers['x-request-id'] = req.headers['x-request-id'] || generateRequestId();
+    req.logger = app.logger.child({request_id: req.headers['x-request-id']});
+    req.logger.log('trace/req', {req: reqForLog(req), msg: 'incoming request'});
+}
+
+
 module.exports = {
     HTTPError: HTTPError,
+    initAndLogRequest: initAndLogRequest,
     wrapRouteHandlers: wrapRouteHandlers,
     setErrorHandler: setErrorHandler,
     router: createRouter

--- a/test/features/ex/errors.js
+++ b/test/features/ex/errors.js
@@ -43,7 +43,7 @@ describe('errors', function() {
             // inspect the status
             assert.deepEqual(err.status, 500);
             // check the error title
-            assert.deepEqual(err.body.title, 'OperationalError');
+            assert.deepEqual(err.body.title, 'Error');
         });
     });
 


### PR DESCRIPTION
- allow routes to return a promise instead of an object, and wait for it to load
- on each request, app should only append logger once, not once per router
- added utils.initAndLogRequest() to append logger and log trace the request
- utils.wrapRouteHandlers() no longer appends x-request-id header and req.logger
- Fixed param documentation
- gitignore .idea
