### PR TITLE
Add the access-control-expose-headers header

### DIFF
--- a/app.js
+++ b/app.js
@@ -82,15 +82,16 @@ function initApp(options) {
     // set the CORS and CSP headers
     app.all('*', function(req, res, next) {
         if(app.conf.cors !== false) {
-            res.header('Access-Control-Allow-Origin', app.conf.cors);
-            res.header('Access-Control-Allow-Headers', 'Accept, X-Requested-With, Content-Type');
+            res.header('access-control-allow-origin', app.conf.cors);
+            res.header('access-control-allow-headers', 'accept, x-requested-with, content-type');
+            res.header('access-control-expose-headers', 'etag');
         }
-        res.header('X-XSS-Protection', '1; mode=block');
-        res.header('X-Content-Type-Options', 'nosniff');
-        res.header('X-Frame-Options', 'SAMEORIGIN');
-        res.header('Content-Security-Policy', app.conf.csp);
-        res.header('X-Content-Security-Policy', app.conf.csp);
-        res.header('X-WebKit-CSP', app.conf.csp);
+        res.header('x-xss-protection', '1; mode=block');
+        res.header('x-content-type-options', 'nosniff');
+        res.header('x-frame-options', 'SAMEORIGIN');
+        res.header('content-security-policy', app.conf.csp);
+        res.header('x-content-security-policy', app.conf.csp);
+        res.header('x-webkit-csp', app.conf.csp);
 
         sUtil.initAndLogRequest(req, app);
 

--- a/test/features/app/app.js
+++ b/test/features/app/app.js
@@ -31,7 +31,8 @@ describe('express app', function() {
         }).then(function(res) {
             assert.deepEqual(res.status, 200);
             assert.deepEqual(res.headers['access-control-allow-origin'], '*');
-            assert.notDeepEqual(res.headers['access-control-allow-headers'], undefined);
+            assert.deepEqual(!!res.headers['access-control-allow-headers'], true);
+            assert.deepEqual(!!res.headers['access-control-expose-headers'], true);
         });
     });
 


### PR DESCRIPTION
The `access-control-expose-headers` header allows browser clients doing cross-site scripting to see additional headers. Here, we set it to `etag` only. Also, lowercase header names.
