### PR TITLE
Logging: header blacklisting

### DIFF
--- a/app.js
+++ b/app.js
@@ -52,6 +52,16 @@ function initApp(options) {
         }
     }
 
+    // set up header blacklisting for logging
+    if(!app.conf.log_header_blacklist) {
+        app.conf.log_header_blacklist = ['set-cookie', 'x-client-ip', 'x-forwarded-for'];
+    } else if(typeof app.conf.log_header_blacklist === 'string') {
+        app.conf.log_header_blacklist = app.conf.log_header_blacklist.split(/,/);
+    }
+    app.conf.log_header_blacklist = new RegExp(app.conf.log_header_blacklist.map(function(item) {
+        return item.trim();
+    }).join('|'), 'i');
+
     // set up the spec
     if(!app.conf.spec) {
         app.conf.spec = __dirname + '/spec.yaml';

--- a/app.js
+++ b/app.js
@@ -54,13 +54,13 @@ function initApp(options) {
 
     // set up header blacklisting for logging
     if(!app.conf.log_header_blacklist) {
-        app.conf.log_header_blacklist = ['set-cookie', 'x-client-ip', 'x-forwarded-for'];
+        app.conf.log_header_blacklist = ['cookie', 'set-cookie', 'x-client-ip', 'x-forwarded-for'];
     } else if(typeof app.conf.log_header_blacklist === 'string') {
         app.conf.log_header_blacklist = app.conf.log_header_blacklist.split(/,/);
     }
-    app.conf.log_header_blacklist = new RegExp(app.conf.log_header_blacklist.map(function(item) {
+    app.conf.log_header_blacklist = new RegExp('^' + app.conf.log_header_blacklist.map(function(item) {
         return item.trim();
-    }).join('|'), 'i');
+    }).join('|') + '$', 'i');
 
     // set up the spec
     if(!app.conf.spec) {

--- a/config.dev.yaml
+++ b/config.dev.yaml
@@ -48,8 +48,8 @@ services:
       #   - domain1.com
       #   - domain2.org
       # the list of incoming request headers that should not be logged; if
-      # left empty, set-cookie, x-forwarded-for and x-client-ip are removed
-      # by default
+      # left empty, cookie, set-cookie, x-forwarded-for and x-client-ip are
+      # removed by default
       # log_header_blacklist:
       #   - set-cookie
       #   - x-my-header

--- a/config.dev.yaml
+++ b/config.dev.yaml
@@ -47,3 +47,10 @@ services:
       # no_proxy_list:
       #   - domain1.com
       #   - domain2.org
+      # the list of incoming request headers that should not be logged; if
+      # left empty, set-cookie, x-forwarded-for and x-client-ip are removed
+      # by default
+      # log_header_blacklist:
+      #   - set-cookie
+      #   - x-my-header
+      #   - x-your-header

--- a/lib/util.js
+++ b/lib/util.js
@@ -45,14 +45,15 @@ util.inherits(HTTPError, Error);
 /**
  * Generates an object suitable for logging out of a request object
  *
- * @param {Request} req request
+ * @param {Request} req          the request to log
+ * @param {RegExp}  blacklistRE  the RegExp used to filter headers
  * @return {Object} an object containing the key components of the request
  */
-function reqForLog(req) {
+function reqForLog(req, blacklistRE) {
 
-    return {
+    var ret = {
         url: req.originalUrl,
-        headers: req.headers,
+        headers: Object.assign({}, req.headers),
         method: req.method,
         params: req.params,
         query: req.query,
@@ -60,6 +61,16 @@ function reqForLog(req) {
         remoteAddress: req.connection.remoteAddress,
         remotePort: req.connection.remotePort
     };
+
+    if(blacklistRE) {
+        Object.keys(ret.headers).forEach(function(hdr) {
+            if(blacklistRE.test(hdr)) {
+                delete ret.headers[hdr];
+            }
+        });
+    }
+
+    return ret;
 
 }
 
@@ -233,7 +244,7 @@ function initAndLogRequest(req, app) {
     req.headers = req.headers || {};
     req.headers['x-request-id'] = req.headers['x-request-id'] || generateRequestId();
     req.logger = app.logger.child({request_id: req.headers['x-request-id']});
-    req.logger.log('trace/req', {req: reqForLog(req), msg: 'incoming request'});
+    req.logger.log('trace/req', {req: reqForLog(req, app.conf.log_header_blacklist), msg: 'incoming request'});
 }
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-template-node",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A blueprint for MediaWiki REST API services",
   "main": "./app.js",
   "scripts": {
@@ -29,23 +29,23 @@
   "homepage": "https://github.com/wikimedia/service-template-node",
   "dependencies": {
     "bluebird": "~2.8.2",
-    "body-parser": "^1.13.2",
-    "bunyan": "^1.4.0",
+    "body-parser": "^1.14.1",
+    "bunyan": "^1.5.1",
     "cassandra-uuid": "^0.0.2",
-    "compression": "^1.5.1",
-    "domino": "^1.0.18",
-    "express": "^4.13.1",
-    "js-yaml": "^3.3.1",
+    "compression": "^1.6.0",
+    "domino": "^1.0.19",
+    "express": "^4.13.3",
+    "js-yaml": "^3.4.3",
     "preq": "^0.4.4",
-    "service-runner": "^0.2.1"
+    "service-runner": "^0.2.10"
   },
   "devDependencies": {
     "extend": "^3.0.0",
-    "istanbul": "^0.3.17",
-    "mocha": "^2.2.5",
+    "istanbul": "^0.3.22",
+    "mocha": "^2.3.3",
     "mocha-jshint": "^2.2.3",
-    "mocha-lcov-reporter": "^0.0.2",
-    "swagger-router": "^0.1.1"
+    "mocha-lcov-reporter": "^1.0.0",
+    "swagger-router": "^0.1.2"
   },
   "deploy": {
     "target": "ubuntu",


### PR DESCRIPTION
This PR allows service developers to blacklist a specific set of headers when logging them. By default, `set-cookie`, `cookie`, `x-client-ip` and `x-forwarded-for` are removed. Developers may define their own set of headers to blacklist by adding a `log_header_blacklist` stanza to their service's configuration.

Bug: [T112072](https://phabricator.wikimedia.org/T112072)
