### PR TITLE
Logging: header whitelisting

### DIFF
--- a/app.js
+++ b/app.js
@@ -52,6 +52,17 @@ function initApp(options) {
         }
     }
 
+    // set up header whitelisting for logging
+    if(!app.conf.log_header_whitelist) {
+        app.conf.log_header_whitelist = [
+                'cache-control', 'content-type', 'content-length', 'if-match',
+                'user-agent', 'x-request-id'
+        ];
+    }
+    app.conf.log_header_whitelist = new RegExp('^(?:' + app.conf.log_header_whitelist.map(function(item) {
+        return item.trim();
+    }).join('|') + ')$', 'i');
+
     // set up the spec
     if(!app.conf.spec) {
         app.conf.spec = __dirname + '/spec.yaml';

--- a/config.dev.yaml
+++ b/config.dev.yaml
@@ -47,3 +47,13 @@ services:
       # no_proxy_list:
       #   - domain1.com
       #   - domain2.org
+      # the list of incoming request headers that can be logged; if left empty,
+      # the following headers are allowed: cache-control, content-length,
+      # content-type, if-match, user-agent, x-request-id
+      # log_header_whitelist:
+      #   - cache-control
+      #   - content-length
+      #   - content-type
+      #   - if-match
+      #   - user-agent
+      #   - x-request-id

--- a/lib/util.js
+++ b/lib/util.js
@@ -45,14 +45,15 @@ util.inherits(HTTPError, Error);
 /**
  * Generates an object suitable for logging out of a request object
  *
- * @param {Request} req request
+ * @param {Request} req          the request
+ * @param {RegExp}  whitelistRE  the RegExp used to filter headers
  * @return {Object} an object containing the key components of the request
  */
-function reqForLog(req) {
+function reqForLog(req, whitelistRE) {
 
-    return {
+    var ret = {
         url: req.originalUrl,
-        headers: req.headers,
+        headers: {},
         method: req.method,
         params: req.params,
         query: req.query,
@@ -60,6 +61,16 @@ function reqForLog(req) {
         remoteAddress: req.connection.remoteAddress,
         remotePort: req.connection.remotePort
     };
+
+    if(req.headers && whitelistRE) {
+        Object.keys(req.headers).forEach(function(hdr) {
+            if(whitelistRE.test(hdr)) {
+                ret.headers[hdr] = req.headers[hdr];
+            }
+        });
+    }
+
+    return ret;
 
 }
 
@@ -233,7 +244,7 @@ function initAndLogRequest(req, app) {
     req.headers = req.headers || {};
     req.headers['x-request-id'] = req.headers['x-request-id'] || generateRequestId();
     req.logger = app.logger.child({request_id: req.headers['x-request-id']});
-    req.logger.log('trace/req', {req: reqForLog(req), msg: 'incoming request'});
+    req.logger.log('trace/req', {req: reqForLog(req, app.conf.log_header_whitelist), msg: 'incoming request'});
 }
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-template-node",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A blueprint for MediaWiki REST API services",
   "main": "./app.js",
   "scripts": {
@@ -29,23 +29,23 @@
   "homepage": "https://github.com/wikimedia/service-template-node",
   "dependencies": {
     "bluebird": "~2.8.2",
-    "body-parser": "^1.13.2",
-    "bunyan": "^1.4.0",
+    "body-parser": "^1.14.1",
+    "bunyan": "^1.5.1",
     "cassandra-uuid": "^0.0.2",
-    "compression": "^1.5.1",
-    "domino": "^1.0.18",
-    "express": "^4.13.1",
-    "js-yaml": "^3.3.1",
+    "compression": "^1.6.0",
+    "domino": "^1.0.19",
+    "express": "^4.13.3",
+    "js-yaml": "^3.4.3",
     "preq": "^0.4.4",
-    "service-runner": "^0.2.1"
+    "service-runner": "^0.2.11"
   },
   "devDependencies": {
     "extend": "^3.0.0",
-    "istanbul": "^0.3.17",
-    "mocha": "^2.2.5",
+    "istanbul": "^0.3.22",
+    "mocha": "^2.3.3",
     "mocha-jshint": "^2.2.3",
-    "mocha-lcov-reporter": "^0.0.2",
-    "swagger-router": "^0.1.1"
+    "mocha-lcov-reporter": "^1.0.0",
+    "swagger-router": "^0.2.0"
   },
   "deploy": {
     "target": "ubuntu",


### PR DESCRIPTION
Headers can and often do contain sensitive user information (IP, cookies, etc.) which should not be kept around and stored. Here we set up configuration-based header whitelisting. By default, the following headers are whitelisted:
- `cache-control`
- `content-type`
- `content-length`
- `if-match`
- `user-agent`
- `x-request-id`

Bug: [T112072](https://phabricator.wikimedia.org/T112072)
