### PR TITLE
Document deploy.remote option and node version settings

### DIFF
--- a/doc/deployment.md
+++ b/doc/deployment.md
@@ -117,6 +117,12 @@ That will make the system look for the repository
 `mediawiki/services/name_in_gerrit` when checking it out in the deploy
 repository.
 
+In case remote name in your deploy repository is different from standard `origin`,
+you could configure an alternative name using the following command:
+```
+git config deploy.remote deploy_repo_remote_name
+```
+
 ## Testing
 
 Before updating the deploy repository you need to make sure your configuration

--- a/doc/deployment.md
+++ b/doc/deployment.md
@@ -63,10 +63,10 @@ The first part of the configuration involves keeping your source repository's
 Depending on the exact machine on which your service will be deployed, you may
 need to set `target` to either `ubuntu` or `debian`. 
 
-If you want to specify node.js version, different from the official distribution
-package, set a value of `node` stanza to a desired version, following 
+If you want to specify a version of Node.JS, different from the official distribution
+package, set the value of the `node` stanza to the desired version, following 
 [nvm](https://github.com/creationix/nvm) versions naming. 
-To explicitly force official distribution package, `"system"` version could be set.
+To explicitly force official distribution package, `"system"` version can be used.
 
 The important thing is keeping the `dependencies` field up to date at all times.
 There you should list all of the extra packages that are needed in order to
@@ -77,7 +77,7 @@ other, distribution-specific package lists, e.g.:
 ```javascript
 "deploy": {
   "target": "ubuntu",
-  "node": "v4.2.1"
+  "node": "system"
   "dependencies": {
     "ubuntu": ["pkg1", "pkg2"],
     "debian": ["pkgA", "pkgB"],

--- a/doc/deployment.md
+++ b/doc/deployment.md
@@ -77,7 +77,7 @@ other, distribution-specific package lists, e.g.:
 ```javascript
 "deploy": {
   "target": "ubuntu",
-  "node": "system"
+  "node": "system",
   "dependencies": {
     "ubuntu": ["pkg1", "pkg2"],
     "debian": ["pkgA", "pkgB"],
@@ -123,8 +123,9 @@ That will make the system look for the repository
 `mediawiki/services/name_in_gerrit` when checking it out in the deploy
 repository.
 
-In case remote name in your deploy repository is different from standard `origin`,
-you could configure an alternative name using the following command:
+The deploy-repo builder script assumes the name of the remote to check out in 
+the deploy repository is `origin`. An alternative name can be configured by 
+invoking (in the source repository):
 ```
 git config deploy.remote deploy_repo_remote_name
 ```

--- a/doc/deployment.md
+++ b/doc/deployment.md
@@ -61,7 +61,12 @@ repository, but it needs to be configured properly in order to work.
 The first part of the configuration involves keeping your source repository's
 `package.json` updated. Look for its [deploy stanza](../package.json#L49).
 Depending on the exact machine on which your service will be deployed, you may
-need to set `target` to either `ubuntu` or `debian`.
+need to set `target` to either `ubuntu` or `debian`. 
+
+If you want to specify node.js version, different from the official distribution
+package, set a value of `node` stanza to a desired version, following 
+[nvm](https://github.com/creationix/nvm) versions naming. 
+To explicitly force official distribution package, `"system"` version could be set.
 
 The important thing is keeping the `dependencies` field up to date at all times.
 There you should list all of the extra packages that are needed in order to
@@ -72,6 +77,7 @@ other, distribution-specific package lists, e.g.:
 ```javascript
 "deploy": {
   "target": "ubuntu",
+  "node": "v4.2.1"
   "dependencies": {
     "ubuntu": ["pkg1", "pkg2"],
     "debian": ["pkgA", "pkgB"],

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "express": "^4.13.3",
     "js-yaml": "^3.4.3",
     "preq": "^0.4.4",
-    "service-runner": "^0.2.12"
+    "service-runner": "^0.3.1"
   },
   "devDependencies": {
     "extend": "^3.0.0",


### PR DESCRIPTION
An option to configure deploy repository remote name [was added](https://github.com/wikimedia/service-runner/pull/67) to `service-runner`. Also, support for node version selection was added to `service-runner`. This PR updates the deployment documentation to include new options, and bumps the `service-runner` version.
