### PR TITLE
CSP Headers: Allow the configuration of sending the security headers

### DIFF
--- a/app.js
+++ b/app.js
@@ -31,9 +31,9 @@ function initApp(options) {
     // ensure some sane defaults
     if(!app.conf.port) { app.conf.port = 8888; }
     if(!app.conf.interface) { app.conf.interface = '0.0.0.0'; }
-    if(!app.conf.compression_level) { app.conf.compression_level = 3; }
+    if(app.conf.compression_level === undefined) { app.conf.compression_level = 3; }
     if(app.conf.cors === undefined) { app.conf.cors = '*'; }
-    if(!app.conf.csp) {
+    if(app.conf.csp === undefined) {
         app.conf.csp =
             "default-src 'self'; object-src 'none'; media-src *; img-src *; style-src *; frame-ancestors 'self'";
     }
@@ -97,12 +97,14 @@ function initApp(options) {
             res.header('access-control-allow-headers', 'accept, x-requested-with, content-type');
             res.header('access-control-expose-headers', 'etag');
         }
-        res.header('x-xss-protection', '1; mode=block');
-        res.header('x-content-type-options', 'nosniff');
-        res.header('x-frame-options', 'SAMEORIGIN');
-        res.header('content-security-policy', app.conf.csp);
-        res.header('x-content-security-policy', app.conf.csp);
-        res.header('x-webkit-csp', app.conf.csp);
+        if(app.conf.csp !== false) {
+            res.header('x-xss-protection', '1; mode=block');
+            res.header('x-content-type-options', 'nosniff');
+            res.header('x-frame-options', 'SAMEORIGIN');
+            res.header('content-security-policy', app.conf.csp);
+            res.header('x-content-security-policy', app.conf.csp);
+            res.header('x-webkit-csp', app.conf.csp);
+        }
         sUtil.initAndLogRequest(req, app);
         next();
     });

--- a/config.dev.yaml
+++ b/config.dev.yaml
@@ -41,6 +41,8 @@ services:
       # cors: false
       # to restrict to a particular domain, use:
       # cors: restricted.domain.org
+      # content for the CSP headers
+      # csp: false  # uncomment this line to disable sending them
       # URL of the outbound proxy to use (complete with protocol)
       # proxy: http://my.proxy.org:8080
       # the list of domains for which not to use the proxy defined above

--- a/test/features/app/app.js
+++ b/test/features/app/app.js
@@ -26,6 +26,9 @@ describe('express app', function() {
     });
 
     it('should set CORS headers', function() {
+        if(server.config.service.conf.cors === false) {
+            return true;
+        }
         return preq.get({
             uri: server.config.uri + 'robots.txt'
         }).then(function(res) {
@@ -37,6 +40,9 @@ describe('express app', function() {
     });
 
     it('should set CSP headers', function() {
+        if(server.config.service.conf.csp === false) {
+            return true;
+        }
         return preq.get({
             uri: server.config.uri + 'robots.txt'
         }).then(function(res) {

--- a/test/utils/server.js
+++ b/test/utils/server.js
@@ -23,6 +23,7 @@ var config = {
 var myServiceIdx = config.conf.services.length - 1;
 var myService = config.conf.services[myServiceIdx];
 config.uri = 'http://localhost:' + myService.conf.port + '/';
+config.service = myService;
 // no forking, run just one process when testing
 config.conf.num_workers = 0;
 // have a separate, in-memory logger only


### PR DESCRIPTION
Until now, CSP headers were enforced upon a service's response. This PR allows users to disable sending them by setting `csp: false` in the in the service's configuration section.

Also: allow the `compression_level` configuration option to be set to 0 and do not check the response for CORS tests if CORS has been disabled.
