### PR TITLE
Logger: Log the stack trace only for 500 errors

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -88,6 +88,11 @@ function errForLog(err) {
     ret.type = err.type;
     ret.detail = err.detail;
 
+    // log the stack trace only for 500 errors
+    if(Number.parseInt(ret.status) !== 500) {
+        ret.stack = undefined;
+    }
+
     return ret;
 
 }


### PR DESCRIPTION
The logger facility used to be set up so that each error log entry contained the full stack trace as well. However, the stack trace is relevant only for errors with the status code 500, as that represents a "true" service error. For any other code no stack trace is needed, as the assumption is that the service's code handled the exception and emitted the appropriate error code.
