### PR TITLE
Add library functions for accessing the MW and REST APIs

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,6 +8,7 @@ var compression = require('compression');
 var bodyParser = require('body-parser');
 var fs = BBPromise.promisifyAll(require('fs'));
 var sUtil = require('./lib/util');
+var apiUtil = require('./lib/api-util');
 var packageInfo = require('./package.json');
 var yaml = require('js-yaml');
 
@@ -62,6 +63,9 @@ function initApp(options) {
     app.conf.log_header_whitelist = new RegExp('^(?:' + app.conf.log_header_whitelist.map(function(item) {
         return item.trim();
     }).join('|') + ')$', 'i');
+
+    // set up the request templates for the APIs
+    apiUtil.setupApiTemplates(app);
 
     // set up the spec
     if(!app.conf.spec) {

--- a/app.js
+++ b/app.js
@@ -109,6 +109,9 @@ function initApp(options) {
         next();
     });
 
+    // set up the user agent header string to use for requests
+    app.conf.user_agent = app.conf.user_agent || app.info.name;
+
     // disable the X-Powered-By header
     app.set('x-powered-by', false);
     // disable the ETag header - users should provide them!

--- a/config.dev.yaml
+++ b/config.dev.yaml
@@ -71,7 +71,7 @@ services:
       # the template used for contacting RESTBase
       restbase_req:
         method: '{{request.method}}'
-        uri: https://{domain}/api/rest_v1/{+path}
+        uri: https://{{domain}}/api/rest_v1/{+path}
         query: '{{ default(request.query, {}) }}'
         headers: '{{request.headers}}'
         body: '{{request.body}}'

--- a/config.dev.yaml
+++ b/config.dev.yaml
@@ -59,3 +59,12 @@ services:
       #   - if-match
       #   - user-agent
       #   - x-request-id
+      # the user agent to use when issuing requests
+      # user_agent: service-template-node
+      # the template used for contacting the MW API
+      mwapi_req:
+        method: post
+        uri: http://{{domain}}/w/api.php
+        headers:
+          user-agent: '{{user-agent}}'
+        body: '{{request.query}}'

--- a/config.dev.yaml
+++ b/config.dev.yaml
@@ -64,7 +64,14 @@ services:
       # the template used for contacting the MW API
       mwapi_req:
         method: post
-        uri: http://{{domain}}/w/api.php
+        uri: https://{{domain}}/w/api.php
         headers:
           user-agent: '{{user-agent}}'
-        body: '{{request.query}}'
+        body: '{{ default(request.query, {}) }}'
+      # the template used for contacting RESTBase
+      restbase_req:
+        method: '{{request.method}}'
+        uri: https://{domain}/api/rest_v1/{+path}
+        query: '{{ default(request.query, {}) }}'
+        headers: '{{request.headers}}'
+        body: '{{request.body}}'

--- a/config.prod.yaml
+++ b/config.prod.yaml
@@ -72,7 +72,7 @@ services:
       # the template used for contacting RESTBase
       restbase_req:
         method: '{{request.method}}'
-        uri: http://restbase.svc.eqiad.wmnet/{domain}/v1/{+path}
+        uri: http://restbase.svc.eqiad.wmnet/{{domain}}/v1/{+path}
         query: '{{ default(request.query, {}) }}'
         headers: '{{request.headers}}'
         body: '{{request.body}}'

--- a/config.prod.yaml
+++ b/config.prod.yaml
@@ -33,3 +33,39 @@ services:
       port: 6927
       # interface: localhost # uncomment to only listen on localhost
       # more per-service config settings
+      # the location of the spec, defaults to spec.yaml if not specified
+      # spec: ./spec.template.yaml
+      # allow cross-domain requests to the API (default '*')
+      cors: '*'
+      # to disable use:
+      # cors: false
+      # to restrict to a particular domain, use:
+      # cors: restricted.domain.org
+      # content for the CSP headers
+      # csp: false  # uncomment this line to disable sending them
+      # URL of the outbound proxy to use (complete with protocol)
+      # proxy: http://my.proxy.org:8080
+      # the list of domains for which not to use the proxy defined above
+      # no_proxy_list:
+      #   - domain1.com
+      #   - domain2.org
+      # the list of incoming request headers that can be logged; if left empty,
+      # the following headers are allowed: cache-control, content-length,
+      # content-type, if-match, user-agent, x-request-id
+      # log_header_whitelist:
+      #   - cache-control
+      #   - content-length
+      #   - content-type
+      #   - if-match
+      #   - user-agent
+      #   - x-request-id
+      # the user agent to use when issuing requests
+      # user_agent: service-template-node
+      # the template used for contacting the MW API
+      mwapi_req:
+        method: post
+        uri: http://api.svc.eqiad.wmnet/w/api.php
+        headers:
+          host: '{{request.params.domain}}'
+          user-agent: '{{user-agent}}'
+        body: '{{request.query}}'

--- a/config.prod.yaml
+++ b/config.prod.yaml
@@ -68,4 +68,11 @@ services:
         headers:
           host: '{{request.params.domain}}'
           user-agent: '{{user-agent}}'
-        body: '{{request.query}}'
+        body: '{{ default(request.query, {}) }}'
+      # the template used for contacting RESTBase
+      restbase_req:
+        method: '{{request.method}}'
+        uri: http://restbase.svc.eqiad.wmnet/{domain}/v1/{+path}
+        query: '{{ default(request.query, {}) }}'
+        headers: '{{request.headers}}'
+        body: '{{request.body}}'

--- a/lib/api-util.js
+++ b/lib/api-util.js
@@ -1,0 +1,47 @@
+'use strict';
+
+
+var preq = require('preq');
+var sUtil = require('../lib/util');
+var Template = require('swagger-router').Template;
+
+var HTTPError = sUtil.HTTPError;
+
+
+/**
+ * Calls the MW API with the supplied query as its body
+ *
+ * @param {Object} app the application object
+ * @param {string} domain the domain to issue the request to
+ * @param {Object} query an object with all the query parameters for the MW API
+ * @return {Promise} a promise resolving as the response object from the MW API
+ */
+function mwApiGet(app, domain, query) {
+
+    var request = new Template(app.conf.mwapi_req).expand({
+        request: {
+            params: { domain: domain },
+            headers: { 'user-agent': app.conf.user_agent },
+            query: query
+        }
+    });
+
+    return preq(request).then(function(response) {
+        if(response.status < 200 || response.status > 399) {
+            // there was an error when calling the upstream service, propagate that
+            throw new HTTPError({
+                status: response.status,
+                type: 'api_error',
+                title: 'MW API error',
+                detail: response.body
+            });
+        }
+        return response;
+    });
+}
+
+
+module.exports = {
+    mwApiGet: mwApiGet
+};
+

--- a/lib/api-util.js
+++ b/lib/api-util.js
@@ -38,10 +38,46 @@ function mwApiGet(app, domain, query) {
         }
         return response;
     });
+
+}
+
+
+/**
+ * Calls the REST API with the supplied domain, path and request parameters
+ *
+ * @param {Object} app the application object
+ * @param {string} domain the domain to issue the request for
+ * @param {string} path the REST API path to contact without the leading slash
+ * @param {Object} [restReq={}] the object containing the REST request details
+ * @param {string} [restReq.method=get] the request method
+ * @param {Object} [restReq.query={}] the query string to send, if any
+ * @param {Object} [restReq.headers={}] the request headers to send
+ * @param {Object} [restReq.body=null] the body of the request, if any
+ * @return {Promise} a promise resolving as the response object from the REST API
+ *
+ */
+function restApiGet(app, domain, path, restReq) {
+
+    restReq = restReq || {};
+    path = path[0] === '/' ? path.slice(1) : path;
+
+    var request = new Template(app.conf.restbase_req).expand({
+        request: {
+            method: restReq.method,
+            params: { domain: domain, path: path },
+            query: restReq.query,
+            headers: Object.assign({}, { 'user-agent': app.conf.user_agent }, restReq.headers),
+            body: restReq.body
+        }
+    });
+
+    return preq(request);
+
 }
 
 
 module.exports = {
-    mwApiGet: mwApiGet
+    mwApiGet: mwApiGet,
+    restApiGet: restApiGet
 };
 

--- a/lib/api-util.js
+++ b/lib/api-util.js
@@ -69,7 +69,7 @@ function restApiGet(app, domain, path, restReq) {
             method: restReq.method,
             params: { domain: domain, path: path },
             query: restReq.query,
-            headers: Object.assign({}, { 'user-agent': app.conf.user_agent }, restReq.headers),
+            headers: Object.assign({ 'user-agent': app.conf.user_agent }, restReq.headers),
             body: restReq.body
         }
     });

--- a/lib/api-util.js
+++ b/lib/api-util.js
@@ -18,6 +18,9 @@ var HTTPError = sUtil.HTTPError;
  */
 function mwApiGet(app, domain, query) {
 
+    query = query || {};
+    query.continue = query.continue || '';
+
     var request = new Template(app.conf.mwapi_req).expand({
         request: {
             params: { domain: domain },

--- a/lib/api-util.js
+++ b/lib/api-util.js
@@ -21,7 +21,7 @@ function mwApiGet(app, domain, query) {
     query = query || {};
     query.continue = query.continue || '';
 
-    var request = new Template(app.conf.mwapi_req).expand({
+    var request = app.mwapi_tpl.expand({
         request: {
             params: { domain: domain },
             headers: { 'user-agent': app.conf.user_agent },
@@ -64,7 +64,7 @@ function restApiGet(app, domain, path, restReq) {
     restReq = restReq || {};
     path = path[0] === '/' ? path.slice(1) : path;
 
-    var request = new Template(app.conf.restbase_req).expand({
+    var request = app.restbase_tpl.expand({
         request: {
             method: restReq.method,
             params: { domain: domain, path: path },
@@ -79,8 +79,43 @@ function restApiGet(app, domain, path, restReq) {
 }
 
 
+/**
+ * Sets up the request templates for MW and RESTBase API requests
+ *
+ * @param {Application} app the application object
+ */
+function setupApiTemplates(app) {
+
+    // set up the MW API request template
+    if(!app.conf.mwapi_req) {
+        app.conf.mwapi_req = {
+            uri: 'http://{{domain}}/w/api.php',
+            headers: {
+                'user-agent': '{{user-agent}}'
+            },
+            body: '{{ default(request.query, {}) }}'
+        };
+    }
+    app.mwapi_tpl = new Template(app.conf.mwapi_req);
+
+    // set up the RESTBase request template
+    if(!app.conf.restbase_req) {
+        app.conf.restbase_req = {
+            method: '{{request.method}}',
+            uri: 'http://{{domain}}/api/rest_v1/{+path}',
+            query: '{{ default(request.query, {}) }}',
+            headers: '{{request.headers}}',
+            body: '{{request.body}}'
+        };
+    }
+    app.restbase_tpl = new Template(app.conf.restbase_req);
+
+}
+
+
 module.exports = {
     mwApiGet: mwApiGet,
-    restApiGet: restApiGet
+    restApiGet: restApiGet,
+    setupApiTemplates: setupApiTemplates
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-template-node",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A blueprint for MediaWiki REST API services",
   "main": "./app.js",
   "scripts": {
@@ -28,22 +28,22 @@
   },
   "homepage": "https://github.com/wikimedia/service-template-node",
   "dependencies": {
-    "bluebird": "^3.3.5",
-    "body-parser": "^1.15.0",
+    "bluebird": "^3.4.0",
+    "body-parser": "^1.15.1",
     "bunyan": "^1.8.1",
     "cassandra-uuid": "^0.0.2",
-    "compression": "^1.6.1",
-    "domino": "^1.0.24",
+    "compression": "^1.6.2",
+    "domino": "^1.0.25",
     "express": "^4.13.4",
-    "js-yaml": "^3.6.0",
+    "js-yaml": "^3.6.1",
     "preq": "^0.4.9",
-    "service-runner": "^1.2.2",
+    "service-runner": "^1.3.0",
     "swagger-router": "^0.4.5"
   },
   "devDependencies": {
     "extend": "^3.0.0",
     "istanbul": "^0.4.3",
-    "mocha": "^2.4.5",
+    "mocha": "^2.5.3",
     "mocha-jshint": "^2.3.1",
     "mocha-lcov-reporter": "^1.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "js-yaml": "^3.6.0",
     "preq": "^0.4.9",
     "service-runner": "^1.2.2",
-    "swagger-router": "^0.4.2"
+    "swagger-router": "^0.4.5"
   },
   "devDependencies": {
     "extend": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -37,15 +37,15 @@
     "express": "^4.13.4",
     "js-yaml": "^3.6.0",
     "preq": "^0.4.9",
-    "service-runner": "^1.2.2"
+    "service-runner": "^1.2.2",
+    "swagger-router": "^0.4.2"
   },
   "devDependencies": {
     "extend": "^3.0.0",
     "istanbul": "^0.4.3",
     "mocha": "^2.4.5",
     "mocha-jshint": "^2.3.1",
-    "mocha-lcov-reporter": "^1.2.0",
-    "swagger-router": "^0.4.2"
+    "mocha-lcov-reporter": "^1.2.0"
   },
   "deploy": {
     "target": "debian",

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -94,7 +94,7 @@ router.get('/siteinfo/:prop?', function(req, res) {
 function getBody(domain, title) {
 
     // get the page
-    return apiUtil.restApiGet(app, domain, 'page/html/' + title/*, {method: 'post'}*/)
+    return apiUtil.restApiGet(app, domain, 'page/html/' + title)
     .then(function(callRes) {
         // and then load and parse the page
         return BBPromise.resolve(domino.createDocument(callRes.body));

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -84,7 +84,7 @@ router.get('/siteinfo/:prop?', function(req, res) {
  ****************************/
 
 /**
- * A helper function that obtains the HTML for a given title and
+ * A helper function that obtains the Parsoid HTML for a given title and
  * loads it into a domino DOM document instance.
  *
  * @param {String} domain the domain to contact
@@ -94,12 +94,8 @@ router.get('/siteinfo/:prop?', function(req, res) {
 function getBody(domain, title) {
 
     // get the page
-    return preq.get({
-        uri: 'http://' + domain + '/w/index.php',
-        query: {
-            title: title
-        }
-    }).then(function(callRes) {
+    return apiUtil.restApiGet(app, domain, 'page/html/' + title/*, {method: 'post'}*/)
+    .then(function(callRes) {
         // and then load and parse the page
         return BBPromise.resolve(domino.createDocument(callRes.body));
     });
@@ -135,7 +131,7 @@ router.get('/page/:title/lead', function(req, res) {
     .then(function(doc) {
         var leadSec = '';
         // find all paragraphs directly under the content div
-        var ps = doc.querySelectorAll('#mw-content-text > p') || [];
+        var ps = doc.querySelectorAll('p') || [];
         for(var idx = 0; idx < ps.length; idx++) {
             var child = ps[idx];
             // find the first paragraph that is not empty

--- a/test/features/v1/page.js
+++ b/test/features/v1/page.js
@@ -13,7 +13,7 @@ describe('page gets', function() {
     before(function () { return server.start(); });
 
     // common URI prefix for the page
-    var uri = server.config.uri + 'en.wikipedia.org/v1/page/Mulholland%20Drive%20%28film%29/';
+    var uri = server.config.uri + 'en.wikipedia.org/v1/page/Mulholland_Drive_(film)/';
 
     it('should get the whole page body', function() {
         return preq.get({
@@ -26,7 +26,7 @@ describe('page gets', function() {
             // inspect the body
             assert.notDeepEqual(res.body, undefined, 'No body returned!');
             // this should be the right page
-            if(!/<\s*?h1.+Mulholland/.test(res.body)) {
+            if(!/mw:PageProp\/displaytitle.+Mulholland/.test(res.body)) {
                 throw new Error('Not the title I was expecting!');
             }
         });


### PR DESCRIPTION
Various services need to make requests against either the MW Action API or the REST API (some need both). Up until now, each service had to come up with its own way of doing that. This PR proposes a unified way of making such calls, hence alleviating the burden off of service developers.
