### PR TITLE
Include core-js and bump service-runner to v2.0.4

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,8 @@
 'use strict';
 
 
+require('core-js/shim');
+
 var http = require('http');
 var BBPromise = require('bluebird');
 var express = require('express');
@@ -197,7 +199,7 @@ function createServer(app) {
         );
     }).then(function () {
         app.logger.log('info',
-            'Worker ' + process.pid + ' listening on ' + app.conf.interface + ':' + app.conf.port);
+            'Worker ' + process.pid + ' listening on ' + (app.conf.interface || '*') + ':' + app.conf.port);
         return server;
     });
 

--- a/package.json
+++ b/package.json
@@ -33,11 +33,12 @@
     "bunyan": "^1.8.1",
     "cassandra-uuid": "^0.0.2",
     "compression": "^1.6.2",
+    "core-js": "^2.4.1",
     "domino": "^1.0.25",
     "express": "^4.14.0",
     "js-yaml": "^3.6.1",
     "preq": "^0.4.10",
-    "service-runner": "^2.0.3",
+    "service-runner": "^2.0.4",
     "swagger-router": "^0.4.6"
   },
   "devDependencies": {


### PR DESCRIPTION
service-runner v2 removes the automatic inclusion of core-js, so
resurect it in the service template. Also, bump service-runner's
version requirement to v2.0.4, as the previous version contained a bug
precluding the service to start when `no_workers > 0`.
