### PR TITLE
Automatically send metrics for each incoming request

### DIFF
--- a/app.js
+++ b/app.js
@@ -160,15 +160,20 @@ function loadRoutes (app) {
             if(route.constructor !== Object || !route.path || !route.router || !(route.api_version || route.skip_domain)) {
                 throw new TypeError('routes/' + fname + ' does not export the correct object!');
             }
-            // wrap the route handlers with Promise.try() blocks
-            sUtil.wrapRouteHandlers(route.router);
-            // determine the path prefix
-            var prefix = '';
-            if(!route.skip_domain) {
-                prefix = '/:domain/v' + route.api_version;
+            // normalise the path to be used as the mount point
+            if(route.path[0] !== '/') {
+                route.path = '/' + route.path;
             }
+            if(route.path[route.path.length - 1] !== '/') {
+                route.path = route.path + '/';
+            }
+            if(!route.skip_domain) {
+                route.path = '/:domain/v' + route.api_version + route.path;
+            }
+            // wrap the route handlers with Promise.try() blocks
+            sUtil.wrapRouteHandlers(route, app);
             // all good, use that route
-            app.use(prefix + route.path, route.router);
+            app.use(route.path, route.router);
         });
     }).then(function () {
         // catch errors

--- a/lib/util.js
+++ b/lib/util.js
@@ -115,18 +115,38 @@ function generateRequestId() {
  * regardless of whether a handler returns/uses promises
  * or not.
  *
- * @param {Router} router object
+ * @param {Object} route the object containing the router and path to bind it to
+ * @param {Application} app the application object
  */
-function wrapRouteHandlers(router) {
+function wrapRouteHandlers(route, app) {
 
-    router.stack.forEach(function(routerLayer) {
+    route.router.stack.forEach(function(routerLayer) {
+        var path = (route.path + routerLayer.route.path.slice(1))
+            .replace(/\/:/g, '/--')
+            .replace(/^\//, '')
+            .replace(/[\/?]+$/, '');
+        path = app.metrics.normalizeName(path || 'root');
         routerLayer.route.stack.forEach(function(layer) {
             var origHandler = layer.handle;
             layer.handle = function(req, res, next) {
+                var startTime = Date.now();
                 BBPromise.try(function() {
                     return origHandler(req, res, next);
                 })
-                .catch(next);
+                .catch(next)
+                .finally(function() {
+                    var statusCode = parseInt(res.statusCode) || 500;
+                    if(statusCode < 100 || statusCode > 599) {
+                        statusCode = 500;
+                    }
+                    var statusClass = Math.floor(statusCode / 100) + 'xx';
+                    var stat = path + '.' + req.method + '.';
+                    app.metrics.endTiming([
+                        stat + statusCode,
+                        stat + statusClass,
+                        stat + 'ALL'
+                    ], startTime);
+                });
             };
         });
     });


### PR DESCRIPTION
service-runner provides a metrics collection facility. Up until now, it
was up to service developers to use it and expose the metrics they want.
However, as all services respond to REST API requests, a generic way of
exposing per-endpoint metrics is needed. This commit enables that.

Bug: [T139673](https://phabricator.wikimedia.org/T139673)
