### PR TITLE
Hygiene: shorten require path for util.js in api-util.js

### DIFF
--- a/lib/api-util.js
+++ b/lib/api-util.js
@@ -2,7 +2,7 @@
 
 
 var preq = require('preq');
-var sUtil = require('../lib/util');
+var sUtil = require('./util');
 var Template = require('swagger-router').Template;
 
 var HTTPError = sUtil.HTTPError;


### PR DESCRIPTION
No need to look beyond the current directory.
