### PR TITLE
NPM Scripts: Add `test-build`

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "PREQ_CONNECT_TIMEOUT=15 mocha && nsp check",
     "docker-start": "service-runner docker-start",
     "docker-test": "service-runner docker-test",
+    "test-build": "service-runner docker-test && service-runner build --deploy-repo --force",
     "coverage": "istanbul cover _mocha -- -R spec"
   },
   "repository": {


### PR DESCRIPTION
The `test-build` NPM script runs the tests in a Docker container using
the `service-runner docker-test` command and then builds the deploy
repository using `service-runner build --deploy-repo --force`.

In order to use this functionality, users need to issue the
`npm run test-build` command. If they also want to include other
arguments to `service-runner build` (such as `--verbose` or `--review`),
they can be added after a `--`, e.g. `npm run test-build -- --review`.