### PR TITLE
Release v0.5.1

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,8 +1,6 @@
 'use strict';
 
 
-require('core-js/shim');
-
 var http = require('http');
 var BBPromise = require('bluebird');
 var express = require('express');

--- a/lib/util.js
+++ b/lib/util.js
@@ -83,7 +83,7 @@ function errForLog(err) {
     ret.detail = err.detail;
 
     // log the stack trace only for 500 errors
-    if (Number.parseInt(ret.status) !== 500) {
+    if (Number.parseInt(ret.status, 10) !== 500) {
         ret.stack = undefined;
     }
 
@@ -127,7 +127,7 @@ function wrapRouteHandlers(route, app) {
                 BBPromise.try(() => origHandler(req, res, next))
                 .catch(next)
                 .finally(() => {
-                    let statusCode = parseInt(res.statusCode) || 500;
+                    let statusCode = parseInt(res.statusCode, 10) || 500;
                     if (statusCode < 100 || statusCode > 599) {
                         statusCode = 500;
                     }
@@ -204,9 +204,9 @@ function setErrorHandler(app) {
         errObj.detail = errObj.detail || errObj.message || errObj.description || '';
         // adjust the log level based on the status code
         let level = 'error';
-        if (Number.parseInt(errObj.status) < 400) {
+        if (Number.parseInt(errObj.status, 10) < 400) {
             level = 'trace';
-        } else if (Number.parseInt(errObj.status) < 500) {
+        } else if (Number.parseInt(errObj.status, 10) < 500) {
             level = 'info';
         }
         // log the error

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-template-node",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A blueprint for MediaWiki REST API services",
   "main": "./app.js",
   "scripts": {
@@ -29,29 +29,30 @@
   },
   "homepage": "https://github.com/wikimedia/service-template-node",
   "dependencies": {
-    "bluebird": "^3.4.6",
-    "body-parser": "^1.15.2",
-    "bunyan": "^1.8.5",
+    "bluebird": "^3.5.0",
+    "body-parser": "^1.17.1",
+    "bunyan": "^1.8.9",
     "cassandra-uuid": "^0.0.2",
     "compression": "^1.6.2",
-    "core-js": "^2.4.1",
-    "domino": "^1.0.27",
-    "express": "^4.14.0",
-    "js-yaml": "^3.7.0",
-    "preq": "^0.5.0",
-    "service-runner": "^2.1.11",
-    "swagger-router": "^0.5.5",
+    "domino": "^1.0.28",
+    "express": "^4.15.2",
+    "js-yaml": "^3.8.2",
+    "preq": "^0.5.2",
+    "service-runner": "^2.2.5",
+    "swagger-router": "^0.5.6",
     "swagger-ui": "git+https://github.com/wikimedia/swagger-ui#master"
   },
   "devDependencies": {
     "extend": "^3.0.0",
     "istanbul": "^0.4.5",
-    "mocha": "^3.1.2",
+    "mocha": "^3.2.0",
     "mocha-jshint": "^2.3.1",
-    "mocha-lcov-reporter": "^1.2.0",
-    "nsp": "^2.6.2",
+    "mocha-lcov-reporter": "^1.3.0",
+    "nsp": "^2.6.3",
     "mocha-eslint":"^3.0.1",
-    "eslint-config-node-services": "^1.0.6"
+    "eslint": "^3.12.0",
+    "eslint-plugin-json": "^1.2.0",
+    "eslint-config-node-services": "^2.0.2"
   },
   "deploy": {
     "target": "debian",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "deploy": {
     "target": "debian",
-    "node": "4.6.0",
+    "node": "6.9.1",
     "dependencies": {
       "_all": []
     }

--- a/test/features/v1/page.js
+++ b/test/features/v1/page.js
@@ -13,7 +13,7 @@ describe('page gets', function() {
     before(function () { return server.start(); });
 
     // common URI prefix for the page
-    var uri = server.config.uri + 'en.wikipedia.org/v1/page/Mulholland_Drive_(film)/';
+    var uri = server.config.uri + 'en.wikipedia.org/v1/page/Table_(database)/';
 
     it('should get the whole page body', function() {
         return preq.get({
@@ -26,7 +26,7 @@ describe('page gets', function() {
             // inspect the body
             assert.notDeepEqual(res.body, undefined, 'No body returned!');
             // this should be the right page
-            if(!/mw:PageProp\/displaytitle.+Mulholland/.test(res.body)) {
+            if(!/Table_\(database\)#cite/.test(res.body)) {
                 throw new Error('Not the title I was expecting!');
             }
         });
@@ -43,7 +43,7 @@ describe('page gets', function() {
             // inspect the body
             assert.notDeepEqual(res.body, undefined, 'No body returned!');
             // this should be the right page
-            if(!/Mulholland/.test(res.body)) {
+            if(!/Table/.test(res.body)) {
                 throw new Error('Not the page I was expecting!');
             }
             // .. and should start with <div id="lead_section">


### PR DESCRIPTION
- Use Node v6.9.1 for building the deploy repo
- Tests: Use different page to fix tests
- Util: Add radix to `parseInt()`
- Update dependencies
- Remove `corejs`