### PR TITLE
Hygiene: ES6 & formatting cleanup

### DIFF
--- a/lib/api-util.js
+++ b/lib/api-util.js
@@ -9,10 +9,10 @@ const HTTPError = sUtil.HTTPError;
 
 /**
  * Calls the MW API with the supplied query as its body
- * @param {Object} app the application object
+ * @param {!Object} app the application object
  * @param {string} domain the domain to issue the request to
- * @param {Object} query an object with all the query parameters for the MW API
- * @return {Promise} a promise resolving as the response object from the MW API
+ * @param {?Object} query an object with all the query parameters for the MW API
+ * @return {!Promise} a promise resolving as the response object from the MW API
  */
 function mwApiGet(app, domain, query) {
 
@@ -45,15 +45,15 @@ function mwApiGet(app, domain, query) {
 
 /**
  * Calls the REST API with the supplied domain, path and request parameters
- * @param {Object} app the application object
+ * @param {!Object} app the application object
  * @param {string} domain the domain to issue the request for
- * @param {string} path the REST API path to contact without the leading slash
- * @param {Object} [restReq={}] the object containing the REST request details
- * @param {string} [restReq.method=get] the request method
- * @param {Object} [restReq.query={}] the query string to send, if any
- * @param {Object} [restReq.headers={}] the request headers to send
- * @param {Object} [restReq.body=null] the body of the request, if any
- * @return {Promise} a promise resolving as the response object from the REST API
+ * @param {!string} path the REST API path to contact without the leading slash
+ * @param {?Object} [restReq={}] the object containing the REST request details
+ * @param {?string} [restReq.method=get] the request method
+ * @param {?Object} [restReq.query={}] the query string to send, if any
+ * @param {?Object} [restReq.headers={}] the request headers to send
+ * @param {?Object} [restReq.body=null] the body of the request, if any
+ * @return {!Promise} a promise resolving as the response object from the REST API
  *
  */
 function restApiGet(app, domain, path, restReq) {
@@ -78,7 +78,7 @@ function restApiGet(app, domain, path, restReq) {
 
 /**
  * Sets up the request templates for MW and RESTBase API requests
- * @param {Application} app the application object
+ * @param {!Application} app the application object
  */
 function setupApiTemplates(app) {
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -38,9 +38,9 @@ class HTTPError extends Error {
 
 /**
  * Generates an object suitable for logging out of a request object
- * @param {Request} req          the request
- * @param {RegExp}  whitelistRE  the RegExp used to filter headers
- * @return {Object} an object containing the key components of the request
+ * @param {!Request} req          the request
+ * @param {?RegExp}  whitelistRE  the RegExp used to filter headers
+ * @return {!Object} an object containing the key components of the request
  */
 function reqForLog(req, whitelistRE) {
 
@@ -69,9 +69,9 @@ function reqForLog(req, whitelistRE) {
 
 
 /**
- * Serialises an error object in a form suitable for logging
- * @param {Error} err error to serialise
- * @return {Object} the serialised version of the error
+ * Serialises an error object in a form suitable for logging.
+ * @param {!Error} err error to serialise
+ * @return {!Object} the serialised version of the error
  */
 function errForLog(err) {
 
@@ -90,8 +90,8 @@ function errForLog(err) {
 }
 
 /**
- * Generates a unique request ID
- * @return {string} the generated request ID
+ * Generates a unique request ID.
+ * @return {!String} the generated request ID
  */
 function generateRequestId() {
 
@@ -105,8 +105,8 @@ function generateRequestId() {
  * promised try blocks so as to allow catching all errors,
  * regardless of whether a handler returns/uses promises
  * or not.
- * @param {Object} route the object containing the router and path to bind it to
- * @param {Application} app the application object
+ * @param {!Object} route the object containing the router and path to bind it to
+ * @param {!Application} app the application object
  */
 function wrapRouteHandlers(route, app) {
 
@@ -143,9 +143,8 @@ function wrapRouteHandlers(route, app) {
 
 
 /**
- * Generates an error handler for the given applications
- * and installs it. Usage:
- * @param {Application} app the application object to add the handler to
+ * Generates an error handler for the given applications and installs it.
+ * @param {!Application} app the application object to add the handler to
  */
 function setErrorHandler(app) {
 
@@ -224,8 +223,8 @@ function setErrorHandler(app) {
 
 /**
  * Creates a new router with some default options.
- * @param {Object} [opts] additional options to pass to express.Router()
- * @return {Router} a new router object
+ * @param {?Object} [opts] additional options to pass to express.Router()
+ * @return {!Router} a new router object
  */
 function createRouter(opts) {
 
@@ -243,9 +242,9 @@ function createRouter(opts) {
 
 
 /**
- * Adds logger to the request and logs it
- * @param {*} req request object
- * @param {Application} app application object
+ * Adds logger to the request and logs it.
+ * @param {!*} req request object
+ * @param {!Application} app application object
  */
 function initAndLogRequest(req, app) {
     req.headers = req.headers || {};

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "mocha-jshint": "^2.3.1",
     "mocha-lcov-reporter": "^1.3.0",
     "nsp": "^2.6.3",
-    "mocha-eslint":"^3.0.1",
+    "mocha-eslint": "^3.0.1",
     "eslint": "^3.12.0",
     "eslint-config-node-services": "^2.0.2",
     "eslint-config-wikimedia": "^0.4.0",

--- a/server.js
+++ b/server.js
@@ -8,5 +8,5 @@
 // (config.yaml by default, specify other path with -c). It requires the
 // module(s) specified in the config 'services' section (app.js in this
 // example).
-var ServiceRunner = require('service-runner');
+const ServiceRunner = require('service-runner');
 new ServiceRunner().start();

--- a/test/features/app/app.js
+++ b/test/features/app/app.js
@@ -1,33 +1,33 @@
 'use strict';
 
 
-var preq   = require('preq');
-var assert = require('../../utils/assert.js');
-var server = require('../../utils/server.js');
+const preq   = require('preq');
+const assert = require('../../utils/assert.js');
+const server = require('../../utils/server.js');
 
 
 describe('express app', function() {
 
-    this.timeout(20000);
+    this.timeout(20000); // eslint-disable-line no-invalid-this
 
-    before(function () { return server.start(); });
+    before(() => { return server.start(); });
 
-    it('should get robots.txt', function() {
+    it('should get robots.txt', () => {
         return preq.get({
-            uri: server.config.uri + 'robots.txt'
-        }).then(function(res) {
+            uri: `${server.config.uri}robots.txt`
+        }).then((res) => {
             assert.deepEqual(res.status, 200);
-            assert.deepEqual(res.headers['disallow'], '/');
+            assert.deepEqual(res.headers.disallow, '/');
         });
     });
 
-    it('should set CORS headers', function() {
-        if(server.config.service.conf.cors === false) {
+    it('should set CORS headers', () => {
+        if (server.config.service.conf.cors === false) {
             return true;
         }
         return preq.get({
-            uri: server.config.uri + 'robots.txt'
-        }).then(function(res) {
+            uri: `${server.config.uri}robots.txt`
+        }).then((res) => {
             assert.deepEqual(res.status, 200);
             assert.deepEqual(res.headers['access-control-allow-origin'], '*');
             assert.deepEqual(!!res.headers['access-control-allow-headers'], true);
@@ -35,13 +35,13 @@ describe('express app', function() {
         });
     });
 
-    it('should set CSP headers', function() {
-        if(server.config.service.conf.csp === false) {
+    it('should set CSP headers', () => {
+        if (server.config.service.conf.csp === false) {
             return true;
         }
         return preq.get({
-            uri: server.config.uri + 'robots.txt'
-        }).then(function(res) {
+            uri: `${server.config.uri}robots.txt`
+        }).then((res) => {
             assert.deepEqual(res.status, 200);
             assert.deepEqual(res.headers['x-xss-protection'], '1; mode=block');
             assert.deepEqual(res.headers['x-content-type-options'], 'nosniff');
@@ -52,27 +52,28 @@ describe('express app', function() {
         });
     });
 
-    it.skip('should get static content gzipped', function() {
+    it.skip('should get static content gzipped', () => {
         return preq.get({
-            uri: server.config.uri + 'static/index.html',
+            uri: `${server.config.uri}static/index.html`,
             headers: {
                 'accept-encoding': 'gzip, deflate'
             }
-        }).then(function(res) {
+        }).then((res) => {
             // check that the response is gzip-ed
             assert.deepEqual(res.headers['content-encoding'], 'gzip', 'Expected gzipped contents!');
         });
     });
 
-    it('should get static content uncompressed', function() {
+    it('should get static content uncompressed', () => {
         return preq.get({
-            uri: server.config.uri + 'static/index.html',
+            uri: `${server.config.uri}static/index.html`,
             headers: {
                 'accept-encoding': ''
             }
-        }).then(function(res) {
+        }).then((res) => {
             // check that the response is gzip-ed
-            assert.deepEqual(res.headers['content-encoding'], undefined, 'Did not expect gzipped contents!');
+            const contentEncoding = res.headers['content-encoding'];
+            assert.deepEqual(contentEncoding, undefined, 'Did not expect gzipped contents!');
         });
     });
 

--- a/test/features/info/info.js
+++ b/test/features/info/info.js
@@ -1,58 +1,58 @@
 'use strict';
 
 
-var preq   = require('preq');
-var assert = require('../../utils/assert.js');
-var server = require('../../utils/server.js');
+const preq   = require('preq');
+const assert = require('../../utils/assert.js');
+const server = require('../../utils/server.js');
 
 
 describe('service information', function() {
 
     this.timeout(20000);
 
-    before(function () { return server.start(); });
+    before(() => { return server.start(); });
 
     // common URI prefix for info tests
-    var infoUri = server.config.uri + '_info/';
+    const infoUri = server.config.uri + '_info/';
 
     // common function used for generating requests
     // and checking their return values
     function checkRet(fieldName) {
         return preq.get({
             uri: infoUri + fieldName
-        }).then(function(res) {
+        }).then((res) => {
             // check the returned Content-Type header
             assert.contentType(res, 'application/json');
             // the status as well
             assert.status(res, 200);
             // finally, check the body has the specified field
             assert.notDeepEqual(res.body, undefined, 'No body returned!');
-            assert.notDeepEqual(res.body[fieldName], undefined, 'No ' + fieldName + ' field returned!');
+            assert.notDeepEqual(res.body[fieldName], undefined, `No ${fieldName} field returned!`);
         });
     }
 
-    it('should get the service name', function() {
+    it('should get the service name', () => {
         return checkRet('name');
     });
 
-    it('should get the service version', function() {
+    it('should get the service version', () => {
         return checkRet('version');
     });
 
-    it('should redirect to the service home page', function() {
+    it('should redirect to the service home page', () => {
         return preq.get({
-            uri: infoUri + 'home',
+            uri: `${infoUri}home`,
             followRedirect: false
-        }).then(function(res) {
+        }).then((res) => {
             // check the status
             assert.status(res, 301);
         });
     });
 
-    it('should get the service info', function() {
+    it('should get the service info', () => {
         return preq.get({
             uri: infoUri
-        }).then(function(res) {
+        }).then((res) => {
             // check the status
             assert.status(res, 200);
             // check the returned Content-Type header

--- a/test/utils/server.js
+++ b/test/utils/server.js
@@ -5,24 +5,24 @@
 /* global describe, it, before, beforeEach, after, afterEach */
 
 
-var BBPromise = require('bluebird');
-var ServiceRunner = require('service-runner');
-var logStream = require('./logStream');
-var fs = require('fs');
-var assert = require('./assert');
-var yaml = require('js-yaml');
-var extend = require('extend');
+const BBPromise = require('bluebird');
+const ServiceRunner = require('service-runner');
+const logStream = require('./logStream');
+const fs = require('fs');
+const assert = require('./assert');
+const yaml = require('js-yaml');
+const extend = require('extend');
 
 
 // set up the configuration
-var config = {
-    conf: yaml.safeLoad(fs.readFileSync(__dirname + '/../../config.yaml'))
+let config = {
+    conf: yaml.safeLoad(fs.readFileSync(`${__dirname}/../../config.yaml`))
 };
 // build the API endpoint URI by supposing the actual service
 // is the last one in the 'services' list in the config file
-var myServiceIdx = config.conf.services.length - 1;
-var myService = config.conf.services[myServiceIdx];
-config.uri = 'http://localhost:' + myService.conf.port + '/';
+const myServiceIdx = config.conf.services.length - 1;
+const myService = config.conf.services[myServiceIdx];
+config.uri = `http://localhost:${myService.conf.port}/`;
 config.service = myService;
 // no forking, run just one process when testing
 config.conf.num_workers = 0;
@@ -33,11 +33,11 @@ config.conf.logging = {
     stream: logStream()
 };
 // make a deep copy of it for later reference
-var origConfig = extend(true, {}, config);
+const origConfig = extend(true, {}, config);
 
-var stop = function() { return BBPromise.resolve(); };
-var options = null;
-var runner = new ServiceRunner();
+let stop = () => { return BBPromise.resolve(); };
+let options = null;
+const runner = new ServiceRunner();
 
 
 function start(_options) {
@@ -45,17 +45,17 @@ function start(_options) {
     _options = _options || {};
 
     if (!assert.isDeepEqual(options, _options)) {
-        console.log('server options changed; restarting');
-        return stop().then(function() {
+        console.log('server options changed; restarting'); // eslint-disable-line no-console
+        return stop().then(() => {
             options = _options;
             // set up the config
             config = extend(true, {}, origConfig);
             extend(true, config.conf.services[myServiceIdx].conf, options);
             return runner.start(config.conf)
-            .then(function() {
-                stop = function () {
-                    console.log('stopping test server');
-                    return runner.stop().then(function() {
+            .then(() => {
+                stop = () => {
+                    console.log('stopping test server'); // eslint-disable-line no-console
+                    return runner.stop().then(() => {
                         stop = function() { return BBPromise.resolve(); };
                     });
                 };


### PR DESCRIPTION
Upstreaming changes identified by eslint from mobileapps:
* Consistently use let/const
* Fix whitespace issues
* Use arrow syntax for function calls
* Add parameter nullability indicators to function docs
* Tame line lengths

No functional changes intended.