### PR TITLE
Hygiene: Remove NSP workaround for moment.js

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,5 +1,0 @@
-{
-  "exceptions": [
-    "https://nodesecurity.io/advisories/532"
-  ]
-}


### PR DESCRIPTION
The fix for the moment.js ReDOS issue was released in 2.19.3.  The NSP
exception should be removed and node modules updated as needed.