### PR TITLE
Fix misleading testing utilities and update tests

### DIFF
--- a/test/features/app/app.js
+++ b/test/features/app/app.js
@@ -52,9 +52,11 @@ describe('express app', function() {
             assert.deepEqual(res.headers['x-xss-protection'], '1; mode=block');
             assert.deepEqual(res.headers['x-content-type-options'], 'nosniff');
             assert.deepEqual(res.headers['x-frame-options'], 'SAMEORIGIN');
-            assert.deepEqual(res.headers['content-security-policy'], 'default-src');
-            assert.deepEqual(res.headers['x-content-security-policy'], 'default-src');
-            assert.deepEqual(res.headers['x-webkit-csp'], 'default-src');
+            /* eslint-disable max-len */
+            assert.deepEqual(res.headers['content-security-policy'], 'default-src \'self\'; object-src \'none\'; media-src *; img-src *; style-src *; frame-ancestors \'self\'');
+            assert.deepEqual(res.headers['x-content-security-policy'], 'default-src \'self\'; object-src \'none\'; media-src *; img-src *; style-src *; frame-ancestors \'self\'');
+            assert.deepEqual(res.headers['x-webkit-csp'], 'default-src \'self\'; object-src \'none\'; media-src *; img-src *; style-src *; frame-ancestors \'self\'');
+            /* eslint-enable max-len */
         });
     });
 

--- a/test/utils/assert.js
+++ b/test/utils/assert.js
@@ -9,11 +9,7 @@ const assert = require('assert');
 function deepEqual(result, expected, message) {
 
     try {
-        if (typeof expected === 'string') {
-            assert.ok(result === expected || (new RegExp(expected).test(result)));
-        } else {
-            assert.deepEqual(result, expected, message);
-        }
+        assert.deepEqual(result, expected, message);
     } catch (e) {
         console.log(`Expected:\n${JSON.stringify(expected, null, 2)}`);
         console.log(`Result:\n${JSON.stringify(result, null, 2)}`);
@@ -37,11 +33,11 @@ function status(res, expected) {
 /**
  * Asserts whether content type was as expected
  */
-function contentType(res, expected) {
+function contentType(res, expectedRegexString) {
 
     const actual = res.headers['content-type'];
-    deepEqual(actual, expected,
-        `Expected content-type to be ${expected}, but was ${actual}`);
+    assert.ok(RegExp(expectedRegexString).test(actual),
+        `Expected content-type to match ${expectedRegexString}, but was ${actual}`);
 
 }
 
@@ -49,11 +45,7 @@ function contentType(res, expected) {
 function isDeepEqual(result, expected, message) {
 
     try {
-        if (typeof expected === 'string') {
-            assert.ok(result === expected || (new RegExp(expected).test(result)), message);
-        } else {
-            assert.deepEqual(result, expected, message);
-        }
+        assert.deepEqual(result, expected, message);
         return true;
     } catch (e) {
         return false;


### PR DESCRIPTION
The deepEqual and isDeepEqual wrapper methods in test/util/assert.js
for some reason special-case string comparisons and use RegExp matching
in a way equivalent to String.prototype.includes.  This is confusing
and makes it very easy to write tests resulting in false positives.

This eliminates the alternate string behavior and updates the
tests that are broken by that change.

Fixes #94.