### PR TITLE
Throw an error if the MediaWiki API responds with text/html

### DIFF
--- a/lib/api-util.js
+++ b/lib/api-util.js
@@ -28,7 +28,8 @@ function mwApiGet(app, domain, query) {
     });
 
     return preq(request).then((response) => {
-        if (response.status < 200 || response.status > 399) {
+        if (response.headers['content-type'].includes('text/html')
+            || response.status < 200 || response.status > 399) {
             // there was an error when calling the upstream service, propagate that
             throw new HTTPError({
                 status: response.status,


### PR DESCRIPTION
If we get a response from the MediaWiki API with a 200 response code but a
content type of text/html, it's almost certainly the auto-generated API
help page, which means there was a problem with the request.

Currently, this problem is visible if a request is made to mediawiki.org
(without the www subdomain).

Background: https://phabricator.wikimedia.org/T186745