### PR TITLE
Default to format=json and formatversion=2 in api-util/mwApiGet

### DIFF
--- a/lib/api-util.js
+++ b/lib/api-util.js
@@ -16,8 +16,10 @@ const HTTPError = sUtil.HTTPError;
  */
 function mwApiGet(app, domain, query) {
 
-    query = query || {};
-    query.continue = query.continue || '';
+    query = Object.assign({
+        format: 'json',
+        formatversion: 2
+    }, query);
 
     const request = app.mwapi_tpl.expand({
         request: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-template-node",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "A blueprint for MediaWiki REST API services",
   "main": "./app.js",
   "scripts": {

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -42,10 +42,8 @@ router.get('/siteinfo/:prop?', (req, res) => {
 
     // construct the query for the MW Action API
     const apiQuery = {
-        format: 'json',
         action: 'query',
-        meta: 'siteinfo',
-        continue: ''
+        meta: 'siteinfo'
     };
 
     // send it


### PR DESCRIPTION
It's highly unlikely a user of this template would want a response in a
format other than JSON.  This hard-codes that into mwApiGet so that
consumers can skip the boilerplate and focus on the more relevant params
in their application code.

Updates the v1 siteinfo call to remove the boilerplate params added in
mwApiGet.

Also hard-codes formatversion=2 as we should be encouraging API consumers
to take advantage of this saner output format.