### PR TITLE
Fix example spec validation errors

### DIFF
--- a/spec.template.yaml
+++ b/spec.template.yaml
@@ -12,6 +12,23 @@ info:
     url: http://www.apache.org/licenses/LICENSE-2.0
 x-default-params:
   domain: en.wikipedia.org
+
+parameters:
+  domain:
+    in: path
+    name: domain
+    required: true
+    type: string
+    description: |
+      Project domain for the requested data.
+  title:
+    in: path
+    name: title
+    required: true
+    type: string
+    description: |
+      Page title. Use underscores instead of spaces. Example: `Main_Page`
+
 paths:
   # from routes/root.js
   /robots.txt:
@@ -20,6 +37,13 @@ paths:
         - Root
         - Robots
       description: Gets robots.txt
+      responses:
+        200:
+          description: Success
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
       x-amples:
         - title: robots.txt check
           request: {}
@@ -35,6 +59,13 @@ paths:
       description: The root service end-point
       produces:
         - application/json
+      responses:
+        200:
+          description: Success
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
       x-amples:
         - title: root with no query params
           request: {}
@@ -68,6 +99,23 @@ paths:
       description: Calls the MW API siteinfo action and returns the response
       produces:
         - application/json
+      parameters:
+        - $ref: '#/parameters/domain'
+      responses:
+        200:
+          description: Success
+        404:
+          description: Not Found
+          schema:
+            $ref: '#/definitions/problem'
+        504:
+          description: Server Error
+          schema:
+            $ref: '#/definitions/problem'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
       x-amples:
         - title: site info for default domain
           request: {}
@@ -110,6 +158,20 @@ paths:
       produces:
         - text/html
         - application/json
+      parameters:
+        - $ref: '#/parameters/domain'
+        - $ref: '#/parameters/title'
+      responses:
+        200:
+          description: OK
+        404:
+          description: Not Found
+          schema:
+            $ref: '#/definitions/problem'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
       x-amples:
         - title: get the Foobar page from en.wp.org
           request:
@@ -129,6 +191,20 @@ paths:
       produces:
         - text/html
         - application/json
+      parameters:
+        - $ref: '#/parameters/domain'
+        - $ref: '#/parameters/title'
+      responses:
+        200:
+          description: OK
+        404:
+          description: Not Found
+          schema:
+            $ref: '#/definitions/problem'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
       x-amples:
         - title: get the lead section for Barack Obama
           request:
@@ -146,6 +222,9 @@ paths:
       description: Gets information about the service
       produces:
         - application/json
+      responses:
+        200:
+          description: OK
       x-amples:
         - title: retrieve service info
           request: {}
@@ -166,6 +245,9 @@ paths:
       description: Gets the name of the service
       produces:
         - application/json
+      responses:
+        200:
+          description: OK
       x-amples:
         - title: retrieve service name
           request: {}
@@ -183,6 +265,9 @@ paths:
       description: Gets the running version of the service
       produces:
         - application/json
+      responses:
+        200:
+          description: OK
       x-amples:
         - title: retrieve service version
           request: {}
@@ -198,6 +283,9 @@ paths:
         - Service information
         - Service homepage
       description: Redirects to the home page
+      responses:
+        301:
+          description: Redirect
       x-amples:
         - title: redirect to the home page
           request: {}
@@ -213,6 +301,11 @@ paths:
       description: Generates an internal error due to a wrong array declaration
       produces:
         - application/json
+      responses:
+        500:
+          description: Internal Error
+          schema:
+            $ref: '#/definitions/problem'
       x-amples:
         - title: wrong array declaration example
           request: {}
@@ -229,6 +322,11 @@ paths:
       description: Generates an internal error due to a non-existing file
       produces:
         - application/json
+      responses:
+        500:
+          description: Internal Error
+          schema:
+            $ref: '#/definitions/problem'
       x-amples:
         - title: non-existing file example
           request: {}
@@ -245,6 +343,11 @@ paths:
       description: Generates an internal error due to a user-thrown error
       produces:
         - application/json
+      responses:
+        500:
+          description: Internal Error
+          schema:
+            $ref: '#/definitions/problem'
       x-amples:
         - title: user error example
           request: {}
@@ -261,6 +364,11 @@ paths:
       description: Generates an access-denied error
       produces:
         - application/json
+      responses:
+        403:
+          description: Access Denied
+          schema:
+            $ref: '#/definitions/problem'
       x-amples:
         - title: access denied error example
           request: {}
@@ -277,6 +385,11 @@ paths:
       description: Generates an unauthorised error
       produces:
         - application/json
+      responses:
+        401:
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/problem'
       x-amples:
         - title: unauthorised error example
           request: {}
@@ -284,3 +397,22 @@ paths:
             status: 401
             headers:
               content-type: application/json
+
+definitions:
+  # A https://tools.ietf.org/html/draft-nottingham-http-problem
+  problem:
+    required:
+      - type
+    properties:
+      status:
+        type: integer
+      type:
+        type: string
+      title:
+        type: string
+      detail:
+        type: string
+      method:
+        type: string
+      uri:
+        type: string


### PR DESCRIPTION
Fixes validation errors identified by editor.swagger.io.

The only remaining error pertains to the optional 'prop' path parameter.
Optional path parameters are not legal according to the spec but are
handled by the swagger-ui module.

Fixes #100