### PR TITLE
Fix lint warning

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -91,7 +91,7 @@ function errForLog(err) {
 
 /**
  * Generates a unique request ID.
- * @return {!String} the generated request ID
+ * @return {!string} the generated request ID
  */
 function generateRequestId() {
 


### PR DESCRIPTION
Fixes a lint warning resulting from a new type name capitalization rule.