### PR TITLE
Eliminate the mocha-eslint dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./app.js",
   "scripts": {
     "start": "service-runner",
-    "test": "PREQ_CONNECT_TIMEOUT=15 mocha && nsp check",
+    "test": "PREQ_CONNECT_TIMEOUT=15 mocha && npm run lint && nsp check",
     "lint": "eslint --cache --max-warnings 0 --ext .js --ext .json .",
     "docker-start": "service-runner docker-start",
     "docker-test": "service-runner docker-test",
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "ajv": "^6.5.4",
-    "eslint": "^5.8.0",
+    "eslint": "^5.9.0",
     "eslint-config-node-services": "^2.2.5",
     "eslint-config-wikimedia": "^0.8.1",
     "eslint-plugin-jsdoc": "^3.9.1",
@@ -54,7 +54,6 @@
     "extend": "^3.0.2",
     "istanbul": "^0.4.5",
     "mocha": "^5.2.0",
-    "mocha-eslint": "^4.1.0",
     "mocha-lcov-reporter": "^1.3.0",
     "nsp": "^3.2.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-template-node",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "A blueprint for MediaWiki REST API services",
   "main": "./app.js",
   "scripts": {

--- a/test/features/app/app.js
+++ b/test/features/app/app.js
@@ -69,7 +69,8 @@ describe('express app', function() {
         }).then((res) => {
             assert.deepEqual(res.status, 200);
             // if there is no content-length, the reponse was gzipped
-            assert.deepEqual(res.headers['content-length'], undefined, 'Did not expect the content-length header!');
+            assert.deepEqual(res.headers['content-length'], undefined,
+                'Did not expect the content-length header!');
         });
     });
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,9 +1,0 @@
-'use strict';
-
-// Run eslint as part of normal testing
-require('mocha-eslint')([
-    'lib',
-    'routes'
-], {
-    timeout: 10000
-});


### PR DESCRIPTION
The mocha-eslint package appears abandoned.  It pulls in an older version
of eslint (^4.2.0, currently resolving to 4.19.1) than is required by
eslint-config-wikimedia (^5.9.0).  This is true even for the current mocha-
eslint version.

This patch bumps the requested eslint version to ^5.9.0 and drops the
mocha-eslint dependency in favor of a direct eslint invocation in the npm
test script. One minor spacing change was needed to comply with the update.

Upstreams the related mobileapps change:
https://gerrit.wikimedia.org/r/#/c/mediawiki/services/mobileapps/+/475832/

Bug: https://phabricator.wikimedia.org/T210460