### PR TITLE
Hygiene: Replace eslint-config-node-services with eslint-config-wikimedia

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -8,7 +8,6 @@ rules: {
     'computed-property-spacing': 0,
     'indent': 0,
     'key-spacing': 0,
-    'max-statements-per-line': 0,
     'no-multi-spaces': 0,
     'no-multiple-empty-lines': 0,
     'no-underscore-dangle': 0,

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -17,7 +17,6 @@ rules: {
     'no-unused-vars': 0,
     'one-var': 0,
     'operator-linebreak': 0,
-    'quote-props': 0,
     'quotes': 0,
     'space-before-function-paren': 0,
     'space-in-parens': 0,

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,1 +1,25 @@
-extends: 'eslint-config-node-services'
+extends: wikimedia/server
+rules: {
+    'array-bracket-spacing': 0,
+    'arrow-parens': 0,
+    'camelcase': 0,
+    'comma-dangle': 0,
+    'comma-spacing': 0,
+    'computed-property-spacing': 0,
+    'indent': 0,
+    'key-spacing': 0,
+    'max-statements-per-line': 0,
+    'no-multi-spaces': 0,
+    'no-multiple-empty-lines': 0,
+    'no-underscore-dangle': 0,
+    'no-unused-expressions': 0,
+    'no-restricted-syntax': 0,
+    'no-unused-vars': 0,
+    'one-var': 0,
+    'operator-linebreak': 0,
+    'quote-props': 0,
+    'quotes': 0,
+    'space-before-function-paren': 0,
+    'space-in-parens': 0,
+    'valid-jsdoc': 0,
+}

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -17,7 +17,6 @@ rules: {
     'no-unused-vars': 0,
     'one-var': 0,
     'operator-linebreak': 0,
-    'quotes': 0,
     'space-before-function-paren': 0,
     'space-in-parens': 0,
     'valid-jsdoc': 0,

--- a/app.js
+++ b/app.js
@@ -212,7 +212,7 @@ function createServer(app) {
         // Don't delay incomplete packets for 40ms (Linux default) on
         // pipelined HTTP sockets. We write in large chunks or buffers, so
         // lack of coalescing should not be an issue here.
-        server.on("connection", (socket) => {
+        server.on('connection', (socket) => {
             socket.setNoDelay(true);
         });
 

--- a/app.js
+++ b/app.js
@@ -32,10 +32,18 @@ function initApp(options) {
     app.info = packageInfo;         // this app's package info
 
     // ensure some sane defaults
-    if (!app.conf.port) { app.conf.port = 8888; }
-    if (!app.conf.interface) { app.conf.interface = '0.0.0.0'; }
-    if (app.conf.compression_level === undefined) { app.conf.compression_level = 3; }
-    if (app.conf.cors === undefined) { app.conf.cors = '*'; }
+    if (!app.conf.port) {
+        app.conf.port = 8888;
+    }
+    if (!app.conf.interface) {
+        app.conf.interface = '0.0.0.0';
+    }
+    if (app.conf.compression_level === undefined) {
+        app.conf.compression_level = 3;
+    }
+    if (app.conf.cors === undefined) {
+        app.conf.cors = '*';
+    }
     if (app.conf.csp === undefined) {
         // eslint-disable-next-line max-len
         app.conf.csp = "default-src 'self'; object-src 'none'; media-src *; img-src *; style-src *; frame-ancestors 'self'";

--- a/lib/util.js
+++ b/lib/util.js
@@ -189,11 +189,19 @@ function setErrorHandler(app) {
             });
         }
         // ensure some important error fields are present
-        if (!errObj.status) { errObj.status = 500; }
-        if (!errObj.type) { errObj.type = 'internal_error'; }
+        if (!errObj.status) {
+            errObj.status = 500;
+        }
+        if (!errObj.type) {
+            errObj.type = 'internal_error';
+        }
         // add the offending URI and method as well
-        if (!errObj.method) { errObj.method = req.method; }
-        if (!errObj.uri) { errObj.uri = req.url; }
+        if (!errObj.method) {
+            errObj.method = req.method;
+        }
+        if (!errObj.uri) {
+            errObj.uri = req.url;
+        }
         // some set 'message' or 'description' instead of 'detail'
         errObj.detail = errObj.detail || errObj.message || errObj.description || '';
         // adjust the log level based on the status code

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "service-runner",
     "test": "PREQ_CONNECT_TIMEOUT=15 mocha && npm run lint && nsp check",
-    "lint": "eslint --cache --max-warnings 0 --ext .js --ext .json .",
+    "lint": "eslint --cache --max-warnings 0 .",
     "docker-start": "service-runner docker-start",
     "docker-test": "service-runner docker-test",
     "test-build": "service-runner docker-test && service-runner build --deploy-repo --force",
@@ -46,11 +46,7 @@
   },
   "devDependencies": {
     "ajv": "^6.5.4",
-    "eslint": "^5.9.0",
-    "eslint-config-node-services": "^2.2.5",
-    "eslint-config-wikimedia": "^0.8.1",
-    "eslint-plugin-jsdoc": "^3.9.1",
-    "eslint-plugin-json": "^1.2.1",
+    "eslint-config-wikimedia": "^0.9.0",
     "extend": "^3.0.2",
     "istanbul": "^0.4.5",
     "mocha": "^5.2.0",

--- a/routes/root.js
+++ b/routes/root.js
@@ -24,7 +24,7 @@ router.get('/robots.txt', (req, res) => {
 
     res.set({
         'User-agent': '*',
-        'Disallow': '/'
+        Disallow: '/'
     }).end();
 
 });

--- a/test/features/app/spec.js
+++ b/test/features/app/spec.js
@@ -205,7 +205,9 @@ function validateTestResponse(testCase, res) {
         return true;
     }
     res.body = res.body || '';
-    if (Buffer.isBuffer(res.body)) { res.body = res.body.toString(); }
+    if (Buffer.isBuffer(res.body)) {
+        res.body = res.body.toString();
+    }
     if (expRes.body.constructor !== res.body.constructor) {
         if (expRes.body.constructor === String) {
             res.body = JSON.stringify(res.body);

--- a/test/utils/server.js
+++ b/test/utils/server.js
@@ -31,7 +31,9 @@ config.conf.logging = {
 // make a deep copy of it for later reference
 const origConfig = extend(true, {}, config);
 
-module.exports.stop = () => { return BBPromise.resolve(); };
+module.exports.stop = () => {
+	return BBPromise.resolve();
+};
 let options = null;
 const runner = new ServiceRunner();
 


### PR DESCRIPTION
Drops eslint-config-node-services in favor of the new 'server' preset in eslint-config-wikimedia, and applies most rules.

Upstreams https://gerrit.wikimedia.org/r/#/q/topic:eslint-config-wikimedia.