### PR TITLE
Hygiene: Retire the nsp module

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./app.js",
   "scripts": {
     "start": "service-runner",
-    "test": "PREQ_CONNECT_TIMEOUT=15 mocha && npm run lint && nsp check",
+    "test": "PREQ_CONNECT_TIMEOUT=15 mocha && npm run lint",
     "lint": "eslint --cache --max-warnings 0 --ext .js --ext .json .",
     "docker-start": "service-runner docker-start",
     "docker-test": "service-runner docker-test",
@@ -54,8 +54,7 @@
     "extend": "^3.0.2",
     "istanbul": "^0.4.5",
     "mocha": "^5.2.0",
-    "mocha-lcov-reporter": "^1.3.0",
-    "nsp": "^3.2.1"
+    "mocha-lcov-reporter": "^1.3.0"
   },
   "deploy": {
     "target": "debian",


### PR DESCRIPTION
The nodesecurity.io domain has been decommissioned, and nsp is now
returning errors:

 (+) Client request error: getaddrinfo ENOTFOUND api.nodesecurity.io api.nodesecurity.io:443

Time to move on to `npm audit`.