### PR TITLE
Revert "Fixed Proper /robots.txt handling"

### DIFF
--- a/routes/root.js
+++ b/routes/root.js
@@ -19,10 +19,7 @@ let app;
  */
 router.get('/robots.txt', (req, res) => {
 
-    res.set({
-        'User-agent': '*',
-        Disallow: '/'
-    }).end();
+    res.type('text/plain').end('User-agent: *\nDisallow: /\n');
 
 });
 

--- a/spec.template.yaml
+++ b/spec.template.yaml
@@ -49,9 +49,6 @@ paths:
           request: {}
           response:
             status: 200
-            headers:
-              user-agent: '*'
-              disallow: '/'
   /:
     get:
       tags:

--- a/test/features/app/app.js
+++ b/test/features/app/app.js
@@ -23,7 +23,7 @@ describe('express app', function() {
             uri: `${server.config.uri}robots.txt`
         }).then((res) => {
             assert.deepEqual(res.status, 200);
-            assert.deepEqual(res.headers.disallow, '/');
+            assert.deepEqual(res.body, 'User-agent: *\nDisallow: /\n');
         });
     });
 


### PR DESCRIPTION
This partially reverts commit 67d02b6975dff827f2647957703c2854f7a3a3ce.
The original "standard" says robots.txt is what essentially amounts to a
text/plain file one or more records separated by blanklines, with every
record containing lines of the form "<field>: <value>" essentially

The original standard can be found at http://www.robotstxt.org/orig.html