### PR TITLE
Add Blubber config

### DIFF
--- a/.pipeline/blubber.yaml
+++ b/.pipeline/blubber.yaml
@@ -1,0 +1,28 @@
+version: v3
+base: docker-registry.wikimedia.org/nodejs-slim
+lives:
+  in: /srv/service
+runs:
+  environment: { APP_BASE_PATH: /srv/service }
+
+variants:
+  build:
+    base: docker-registry.wikimedia.org/nodejs-devel
+    apt: { packages: [git, build-essential, python-pkgconfig] }
+    node: { requirements: [package.json] }
+    runs: { environment: { LINK: g++ } }
+  development:
+    includes: [build]
+    apt: { packages: [ca-certificates] }
+    entrypoint: [node, server.js]
+  test:
+    includes: [build]
+    apt: { packages: [ca-certificates] }
+    entrypoint: [npm, test]
+  prep:
+    includes: [build]
+    node: { env: production }
+  production:
+    copies: prep
+    node: { env: production }
+    entrypoint: [node, server.js]


### PR DESCRIPTION
Adds a basic Blubber config that successfully builds all existing
dependencies.

This is in support of new services being built for the k8s pipeline.

Phab: https://phabricator.wikimedia.org/T225228