### PR TITLE
HTTPError: Favour err.detail over err.message if present

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -165,7 +165,7 @@ function setErrorHandler(app) {
                     status: 500,
                     type: 'internal_error',
                     title: err.name,
-                    detail: err.message,
+                    detail: err.detail || err.message,
                     stack: err.stack
                 });
             }


### PR DESCRIPTION
When an error provides the `detail` field, favour displaying it over `message` as it oftentimes provides more useful info.

Bug: [T225329](https://phabricator.wikimedia.org/T225329)