### PR TITLE
update service-runner dependency to 2.8.0 and implement new metrics API

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -98,13 +98,25 @@ function errForLog(err) {
 function wrapRouteHandlers(route, app) {
 
     route.router.stack.forEach((routerLayer) => {
-        let path = (route.path + routerLayer.route.path.slice(1))
+        const path = (route.path + routerLayer.route.path.slice(1))
             .replace(/\/:/g, '/--')
             .replace(/^\//, '')
             .replace(/[/?]+$/, '');
-        path = app.metrics.normalizeName(path || 'root');
         routerLayer.route.stack.forEach((layer) => {
             const origHandler = layer.handle;
+            const metric = app.metrics.makeMetric({
+                type: 'Gauge',
+                name: 'router',
+                prometheus: {
+                    name: 'express_router_request_duration_seconds',
+                    help: 'request duration handled by router in seconds',
+                    staticLabels: { service: app.metrics.getServiceName() }
+                },
+                labels: {
+                    names: ['path', 'method', 'status'],
+                    omitLabelNames: true
+                }
+            });
             layer.handle = (req, res, next) => {
                 const startTime = Date.now();
                 BBPromise.try(() => origHandler(req, res, next))
@@ -114,13 +126,7 @@ function wrapRouteHandlers(route, app) {
                     if (statusCode < 100 || statusCode > 599) {
                         statusCode = 500;
                     }
-                    const statusClass = `${Math.floor(statusCode / 100)}xx`;
-                    const stat = `${path}.${req.method}.`;
-                    app.metrics.endTiming([
-                        stat + statusCode,
-                        stat + statusClass,
-                        `${stat}ALL`
-                    ], startTime);
+                    metric.endTiming(startTime, [path || 'root', req.method, statusCode]);
                 });
             };
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-template-node",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "A blueprint for MediaWiki REST API services",
   "main": "./app.js",
   "scripts": {
@@ -39,7 +39,7 @@
     "http-shutdown": "^1.2.1",
     "js-yaml": "^3.13.1",
     "preq": "^0.5.9",
-    "service-runner": "^2.7.1",
+    "service-runner": "https://github.com/wikimedia/service-runner.git#prometheus_metrics",
     "swagger-router": "^0.7.4",
     "swagger-ui-dist": "^3.22.3",
     "uuid": "^3.3.2"


### PR DESCRIPTION
Initial build will fail because service-runner 2.8.0 has not yet been published.