### PR TITLE
Update linting packages and release version 0.8.0

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,8 +1,6 @@
 {
   "extends": [
-    "wikimedia/server",
-    "wikimedia/node",
-    "wikimedia/language/es2016"
+    "wikimedia/server"
   ],
   "plugins": ["json", "jsdoc"],
   "rules": {
@@ -24,7 +22,6 @@
     "space-in-parens": ["error", "never"],
     "computed-property-spacing": "off",
     "no-multi-spaces": "off",
-    "prefer-const": "error",
     "no-underscore-dangle": "off",
     "array-bracket-spacing": "off"
   }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,25 +4,25 @@
   ],
   "plugins": ["json", "jsdoc"],
   "rules": {
+    "array-bracket-spacing": "off",
     "camelcase": [
       "error",
       {
         "properties": "never"
       }
     ],
+    "computed-property-spacing": "off",
     "indent": ["off", 4],
     "jsdoc/no-undefined-types": "off",
+    "no-multi-spaces": "off",
     "no-shadow": "off",
+    "no-underscore-dangle": "off",
     "no-unused-vars": [
       "error",
       {
         "args": "none"
       }
     ],
-    "space-in-parens": ["error", "never"],
-    "computed-property-spacing": "off",
-    "no-multi-spaces": "off",
-    "no-underscore-dangle": "off",
-    "array-bracket-spacing": "off"
+    "space-in-parens": ["error", "never"]
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,6 +13,8 @@
       }
     ],
     "indent": ["off", 4],
+    "jsdoc/no-undefined-types": "off",
+    "no-shadow": "off",
     "no-unused-vars": [
       "error",
       {

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ language: node_js
 sudo: false
 
 node_js:
-  - "6"
   - "10"
+  - "node"

--- a/app.js
+++ b/app.js
@@ -15,6 +15,7 @@ const path = require('path');
 
 /**
  * Creates an express app and initialises it
+ *
  * @param {Object} options the options to initialise the app with
  * @return {bluebird} the promise resolving to the app object
  */
@@ -36,7 +37,6 @@ function initApp(options) {
     app.conf.compression_level = app.conf.compression_level === undefined ? 3 : app.conf.compression_level;
     app.conf.cors = app.conf.cors === undefined ? '*' : app.conf.cors;
     if (app.conf.csp === undefined) {
-        // eslint-disable-next-line max-len
         app.conf.csp = "default-src 'self'; object-src 'none'; media-src *; img-src *; style-src *; frame-ancestors 'self'";
     }
 
@@ -134,6 +134,7 @@ function initApp(options) {
 
 /**
  * Loads all routes declared in routes/ into the app
+ *
  * @param {Application} app the application object to load routes into
  * @param {string} dir routes folder
  * @return {bluebird} a promise resolving to the app object
@@ -187,6 +188,7 @@ function loadRoutes(app, dir) {
 
 /**
  * Creates and start the service's web server
+ *
  * @param {Application} app the app object to use in the service
  * @return {bluebird} a promise creating the web server
  */
@@ -224,6 +226,7 @@ function createServer(app) {
  * options and the logger- and metrics-reporting objects from
  * service-runner and starts an HTTP server, attaching the application
  * object to it.
+ *
  * @param {Object} options the options to initialise the app with
  * @return {bluebird} HTTP server
  */

--- a/lib/api-util.js
+++ b/lib/api-util.js
@@ -7,6 +7,7 @@ const HTTPError = sUtil.HTTPError;
 
 /**
  * Calls the MW API with the supplied query as its body
+ *
  * @param {!Object} req the incoming request object
  * @param {?Object} query an object with all the query parameters for the MW API
  * @param {?Object} headers additional headers to pass to the MW API
@@ -46,6 +47,7 @@ function mwApiGet(req, query, headers) {
 
 /**
  * Calls the REST API with the supplied domain, path and request parameters
+ *
  * @param {!Object} req the incoming request object
  * @param {?string} path the REST API path to contact without the leading slash
  * @param {?Object} [restReq={}] the object containing the REST request details
@@ -87,6 +89,7 @@ function restApiGet(req, path, restReq) {
 
 /**
  * Sets up the request templates for MW and RESTBase API requests
+ *
  * @param {!Application} app the application object
  */
 function setupApiTemplates(app) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -37,6 +37,7 @@ class HTTPError extends Error {
 
 /**
  * Generates an object suitable for logging out of a request object
+ *
  * @param {!Request} req          the request
  * @param {?RegExp}  whitelistRE  the RegExp used to filter headers
  * @return {!Object} an object containing the key components of the request
@@ -68,6 +69,7 @@ function reqForLog(req, whitelistRE) {
 
 /**
  * Serialises an error object in a form suitable for logging.
+ *
  * @param {!Error} err error to serialise
  * @return {!Object} the serialised version of the error
  */
@@ -92,6 +94,7 @@ function errForLog(err) {
  * promised try blocks so as to allow catching all errors,
  * regardless of whether a handler returns/uses promises
  * or not.
+ *
  * @param {!Object} route the object containing the router and path to bind it to
  * @param {!Application} app the application object
  */
@@ -130,6 +133,7 @@ function wrapRouteHandlers(route, app) {
 
 /**
  * Generates an error handler for the given applications and installs it.
+ *
  * @param {!Application} app the application object to add the handler to
  */
 function setErrorHandler(app) {
@@ -208,6 +212,7 @@ function setErrorHandler(app) {
 
 /**
  * Creates a new router with some default options.
+ *
  * @param {?Object} [opts] additional options to pass to express.Router()
  * @return {!Router} a new router object
  */
@@ -227,6 +232,7 @@ function createRouter(opts) {
 
 /**
  * Adds logger to the request and logs it.
+ *
  * @param {!*} req request object
  * @param {!Application} app application object
  */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-template-node",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "A blueprint for MediaWiki REST API services",
   "main": "./app.js",
   "scripts": {
@@ -59,7 +59,7 @@
   },
   "deploy": {
     "target": "debian",
-    "node": "6.11.1",
+    "node": "10.15.2",
     "dependencies": {
       "_all": []
     }

--- a/package.json
+++ b/package.json
@@ -47,9 +47,9 @@
   },
   "devDependencies": {
     "ajv": "^6.5.4",
-    "eslint-config-wikimedia": "^0.10.0",
-    "eslint-plugin-jsdoc": "^4.0.1",
-    "eslint-plugin-json": "^1.2.1",
+    "eslint-config-wikimedia": "^0.17.0",
+    "eslint-plugin-jsdoc": "^30.6.2",
+    "eslint-plugin-json": "^2.1.2",
     "extend": "^3.0.2",
     "mocha": "^5.2.0",
     "mocha-lcov-reporter": "^1.3.0",

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -74,6 +74,7 @@ router.get('/siteinfo/:prop?', (req, res) => {
 /**
  * A helper function that obtains the Parsoid HTML for a given title and
  * loads it into a domino DOM document instance.
+ *
  * @param {!Object} req the incoming request
  * @return {Promise} a promise resolving as the HTML element object
  */

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -2,8 +2,8 @@
   "extends": "../.eslintrc.json",
   "env": { "mocha": true },
   "rules": {
+    "max-len": "off",
     "no-console": "off",
-    "no-invalid-this": "off",
-    "max-len": "off"
+    "no-invalid-this": "off"
   }
 }

--- a/test/utils/assert.js
+++ b/test/utils/assert.js
@@ -16,6 +16,7 @@ function deepEqual(result, expected, message) {
 
 /**
  * Asserts whether the return status was as expected
+ *
  * @param {Object} res
  * @param {integer} expected
  */
@@ -28,6 +29,7 @@ function status(res, expected) {
 
 /**
  * Asserts whether content type was as expected
+ *
  * @param {Object} res
  * @param {string} expectedRegexString
  */


### PR DESCRIPTION
Update linting packages
 * Add rule overrides for two rules which aren't trivially fixable (no-shadow, jsdoc/no-undefined-types)
 * Fix rule fixable with eslint --fix (add blank line in jsdoc blocks after description)
 * Remove extends/rules now included upstream in wikimedia/server
 * Sort rules alphabetically to make comparisons with other projects using the template easier. 
 * Remove support for node 6, target node 10, and increment minor version. 