### PR TITLE
Harden default CSP settings within app.js

### DIFF
--- a/app.js
+++ b/app.js
@@ -37,7 +37,7 @@ function initApp(options) {
     app.conf.compression_level = app.conf.compression_level === undefined ? 3 : app.conf.compression_level;
     app.conf.cors = app.conf.cors === undefined ? '*' : app.conf.cors;
     if (app.conf.csp === undefined) {
-        app.conf.csp = "default-src 'self'; object-src 'none'; media-src *; img-src *; style-src *; frame-ancestors 'self'";
+        app.conf.csp = "default-src 'self'; object-src 'none'; media-src 'none'; img-src 'none'; style-src 'none'; base-uri 'self'; frame-ancestors 'self'";
     }
 
     // set outgoing proxy
@@ -107,8 +107,6 @@ function initApp(options) {
             res.header('x-content-type-options', 'nosniff');
             res.header('x-frame-options', 'SAMEORIGIN');
             res.header('content-security-policy', app.conf.csp);
-            res.header('x-content-security-policy', app.conf.csp);
-            res.header('x-webkit-csp', app.conf.csp);
         }
         sUtil.initAndLogRequest(req, app);
         next();

--- a/test/features/app/app.js
+++ b/test/features/app/app.js
@@ -48,9 +48,7 @@ describe('express app', function () {
             assert.deepEqual(res.headers['x-xss-protection'], '1; mode=block');
             assert.deepEqual(res.headers['x-content-type-options'], 'nosniff');
             assert.deepEqual(res.headers['x-frame-options'], 'SAMEORIGIN');
-            assert.deepEqual(res.headers['content-security-policy'], 'default-src \'self\'; object-src \'none\'; media-src *; img-src *; style-src *; frame-ancestors \'self\'');
-            assert.deepEqual(res.headers['x-content-security-policy'], 'default-src \'self\'; object-src \'none\'; media-src *; img-src *; style-src *; frame-ancestors \'self\'');
-            assert.deepEqual(res.headers['x-webkit-csp'], 'default-src \'self\'; object-src \'none\'; media-src *; img-src *; style-src *; frame-ancestors \'self\'');
+            assert.deepEqual(res.headers['content-security-policy'], 'default-src \'self\'; object-src \'none\'; media-src \'none\'; img-src \'none\'; style-src \'none\'; base-uri \'self\'; frame-ancestors \'self\'');
         });
     });
 


### PR DESCRIPTION
The Service-Template-Node code is used for many internal
wikimedia services where security headers are likely unnecessary.
Still, if defaults are to be provided, those should be as secure
and up-to-date as possible.  Especially if any service were to
ever be made public in any way or an attacker found some novel
way of exploiting various services lacking sufficient protection
via security headers.  This pull request:

* Hardens default CSP policy, namely adding values of 'none' for
various sources and specifying the base-uri directive.

* Removes the deprecated x-webkit-csp and x-content-security-policy
headers.

Note: per developer.mozilla.org docs, x-frame-options is
obsolete if a frame-ancestors directive is specified within the
CSP.  x-xss-protection is also obsolete with a CSP that disallows
unsafe-inline scripts.  Both of these are satisfied by STN and
can be removed.  access-control-allow-origin should likely not
default to '*', but I don't have a good suggestion of an
appropriate default value that wouldn't potentially break
things somewhat unnecessarily.

Author: @sbassett29

Bug: T262652