### PR TITLE
Remove targets.yaml and deploy stanza

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,12 +56,5 @@
     "mocha.parallel": "^0.15.6",
     "nyc": "^14.1.1",
     "openapi-schema-validator": "^3.0.3"
-  },
-  "deploy": {
-    "target": "debian",
-    "node": "10.15.2",
-    "dependencies": {
-      "_all": []
-    }
   }
 }

--- a/targets.yaml
+++ b/targets.yaml
@@ -1,3 +1,0 @@
-debian: 'debian:jessie'
-ubuntu: 'ubuntu:14.04'
-


### PR DESCRIPTION
targets.yaml and the "deploy" stanza of package.json are no longer needed, since they were part of an old deployment pipeline. 