### PR TITLE
build: Simplify and modernise eslint configuration

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,28 +1,35 @@
 {
-  "extends": [
-    "wikimedia/server"
-  ],
-  "plugins": ["json", "jsdoc"],
-  "rules": {
-    "array-bracket-spacing": "off",
-    "camelcase": [
-      "error",
-      {
-        "properties": "never"
-      }
-    ],
-    "computed-property-spacing": "off",
-    "indent": ["off", 4],
-    "jsdoc/no-undefined-types": "off",
-    "no-multi-spaces": "off",
-    "no-shadow": "off",
-    "no-underscore-dangle": "off",
-    "no-unused-vars": [
-      "error",
-      {
-        "args": "none"
-      }
-    ],
-    "space-in-parens": ["error", "never"]
-  }
+	"extends": [
+		"wikimedia/server",
+		"wikimedia/jsdoc"
+	],
+	"rules": {
+		"array-bracket-spacing": "off",
+		"camelcase": [
+			"error",
+			{
+				"properties": "never"
+			}
+		],
+		"computed-property-spacing": "off",
+		"indent": ["off", 4],
+		"no-multi-spaces": "off",
+		"no-shadow": "off",
+		"no-undefined": "off",
+		"no-underscore-dangle": "off",
+		"no-unused-vars": [
+			"error",
+			{
+				"args": "none"
+			}
+		],
+		"space-in-parens": ["error", "never"],
+		"jsdoc/no-undefined-types": "off"
+	},
+	"overrides": [
+		{
+			"files": [ "**/*.json", "**/*.jsonc" ],
+			"extends": "wikimedia/json"
+		}
+	]
 }

--- a/package.json
+++ b/package.json
@@ -1,61 +1,59 @@
 {
-  "name": "service-template-node",
-  "version": "0.10.0",
-  "description": "A blueprint for MediaWiki REST API services",
-  "main": "./app.js",
-  "scripts": {
-    "start": "service-runner",
-    "test": "npm run lint && PREQ_CONNECT_TIMEOUT=15 mocha",
-    "lint": "eslint --max-warnings 0 --ext .js --ext .json .",
-    "lint:fix": "eslint --fix .",
-    "docker-start": "service-runner docker-start",
-    "docker-test": "service-runner docker-test",
-    "test-build": "service-runner docker-test && service-runner build --deploy-repo --force",
-    "coverage": "PREQ_CONNECT_TIMEOUT=15 nyc --reporter=lcov _mocha"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/wikimedia/service-template-node.git"
-  },
-  "keywords": [
-    "REST",
-    "API",
-    "service template",
-    "MediaWiki"
-  ],
-  "author": "Wikimedia Service Team <services@lists.wikimedia.org>",
-  "contributors": [],
-  "license": "Apache-2.0",
-  "bugs": {
-    "url": "https://phabricator.wikimedia.org/tag/service-template-node/"
-  },
-  "homepage": "https://github.com/wikimedia/service-template-node",
-  "dependencies": {
-    "bluebird": "^3.5.5",
-    "body-parser": "^1.19.0",
-    "bunyan": "^1.8.12",
-    "compression": "^1.7.4",
-    "domino": "^2.1.3",
-    "express": "^4.17.1",
-    "http-shutdown": "^1.2.1",
-    "js-yaml": "^3.13.1",
-    "preq": "^0.5.9",
-    "service-runner": "^2.8.3",
-    "swagger-router": "^0.7.4",
-    "swagger-ui-dist": "^3.22.3",
-    "uuid": "^3.3.2"
-  },
-  "devDependencies": {
-    "ajv": "^6.5.4",
-    "chai": "^4.3.0",
-    "eslint-config-wikimedia": "^0.20.0",
-    "eslint-plugin-jsdoc": "^33.0.0",
-    "eslint-plugin-json": "^2.1.2",
-    "extend": "^3.0.2",
-    "mocha": "^5.2.0",
-    "mocha-lcov-reporter": "^1.3.0",
-    "mocha.parallel": "^0.15.6",
-    "nyc": "^14.1.1",
-    "openapi-schema-validator": "^3.0.3"
-  }
+	"name": "service-template-node",
+	"version": "0.10.0",
+	"description": "A blueprint for MediaWiki REST API services",
+	"main": "./app.js",
+	"scripts": {
+		"start": "service-runner",
+		"test": "npm run lint && PREQ_CONNECT_TIMEOUT=15 mocha",
+		"lint": "eslint --max-warnings 0 --ext .js --ext .json .",
+		"lint:fix": "eslint --fix .",
+		"docker-start": "service-runner docker-start",
+		"docker-test": "service-runner docker-test",
+		"test-build": "service-runner docker-test && service-runner build --deploy-repo --force",
+		"coverage": "PREQ_CONNECT_TIMEOUT=15 nyc --reporter=lcov _mocha"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git://github.com/wikimedia/service-template-node.git"
+	},
+	"keywords": [
+		"REST",
+		"API",
+		"service template",
+		"MediaWiki"
+	],
+	"author": "Wikimedia Service Team <services@lists.wikimedia.org>",
+	"contributors": [],
+	"license": "Apache-2.0",
+	"bugs": {
+		"url": "https://phabricator.wikimedia.org/tag/service-template-node/"
+	},
+	"homepage": "https://github.com/wikimedia/service-template-node",
+	"dependencies": {
+		"bluebird": "^3.5.5",
+		"body-parser": "^1.19.0",
+		"bunyan": "^1.8.12",
+		"compression": "^1.7.4",
+		"domino": "^2.1.3",
+		"express": "^4.17.1",
+		"http-shutdown": "^1.2.1",
+		"js-yaml": "^3.13.1",
+		"preq": "^0.5.9",
+		"service-runner": "^2.8.3",
+		"swagger-router": "^0.7.4",
+		"swagger-ui-dist": "^3.22.3",
+		"uuid": "^3.3.2"
+	},
+	"devDependencies": {
+		"ajv": "^6.5.4",
+		"chai": "^4.3.0",
+		"eslint-config-wikimedia": "0.20.0",
+		"extend": "^3.0.2",
+		"mocha": "^5.2.0",
+		"mocha-lcov-reporter": "^1.3.0",
+		"mocha.parallel": "^0.15.6",
+		"nyc": "^14.1.1",
+		"openapi-schema-validator": "^3.0.3"
+	}
 }

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,9 +1,11 @@
 {
-  "extends": "../.eslintrc.json",
-  "env": { "mocha": true },
-  "rules": {
-    "max-len": "off",
-    "no-console": "off",
-    "no-invalid-this": "off"
-  }
+	"extends": [
+		"../.eslintrc.json",
+		"wikimedia/mocha"
+	],
+	"rules": {
+		"max-len": "off",
+		"no-console": "off",
+		"no-invalid-this": "off"
+	}
 }

--- a/test/features/app/spec.js
+++ b/test/features/app/spec.js
@@ -151,7 +151,7 @@ function cmp(result, expected, errMsg) {
     }
 
     if (expected.length > 1 && expected[0] === '/' && expected[expected.length - 1] === '/') {
-        if ((new RegExp(expected.slice(1, -1))).test(result)) {
+        if (new RegExp(expected.slice(1, -1)).test(result)) {
             return true;
         }
     } else if (expected.length === 0 && result.length === 0) {
@@ -264,11 +264,15 @@ describe('Swagger spec', function () {
         })
         .then((spec) => {
             const routeTests = () => {
+                // eslint-disable-next-line mocha/no-sibling-hooks
                 before(() => server.start());
+                // eslint-disable-next-line mocha/no-sibling-hooks
                 after(() => server.stop());
 
                 constructTests(spec).forEach((testCase) => {
+                    // eslint-disable-next-line mocha/handle-done-callback, mocha/no-nested-tests
                     it(testCase.title, function (done) {
+                    // eslint-disable-next-line mocha/no-return-and-callback
                         return preq(testCase.request)
                         .then((res) => {
                             assert.status(res, testCase.response.status);


### PR DESCRIPTION
Take the opportunity to modernise a bunch of this configuration
in line with how repos downstream are generally using it.

Suppressed some whines from the mocha test suite for now.