### PR TITLE
Target node 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ sudo: false
 
 node_js:
   - "10"
-  - "node"
+  - "12"


### PR DESCRIPTION
https://phabricator.wikimedia.org/T284345 CI jobs on gerrit are now targeting 12 as 10 is EOL, probably we should do this as well.

Actually deploying services with 12 I believe depends on https://phabricator.wikimedia.org/T284346 but presumably this will happen at some point so targeting 12 as well as 10 now makes sense. 