### PR TITLE
README: Drop TravisCI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# service-template-node [![Build Status](https://travis-ci.org/wikimedia/service-template-node.svg?branch=master)](https://travis-ci.org/wikimedia/service-template-node)
+# service-template-node
 
 Template for creating MediaWiki Services in Node.js
 


### PR DESCRIPTION
We intentionally don't render foreign resources in our documentation,
as it's a security vulnerability, so let's not encourage repos to use
badges like this. (Also, travis-ci.*org* is no more, replaced by .com
so this wouldn't work anyway.)