### PR TITLE
remove LINK env variable in default blubber.yaml

### DIFF
--- a/.pipeline/blubber.yaml
+++ b/.pipeline/blubber.yaml
@@ -11,7 +11,6 @@ variants:
     copies: [local]
     apt: { packages: [git, build-essential, python-pkgconfig] }
     node: { requirements: [package.json] }
-    runs: { environment: { LINK: g++ } }
   development:
     includes: [build]
     apt: { packages: [ca-certificates] }


### PR DESCRIPTION
the LINK. env variable was added to address some issues with a Mathoid [build](https://gerrit.wikimedia.org/r/c/mediawiki/services/mathoid/+/395050) awhile back. It's unclear whether or not LINK needs to be set, as some node docker images are built successfully without it (e.g. https://gerrit.wikimedia.org/r/c/mediawiki/services/image-suggestion-api/+/737501) and the original change was added on a node 6 docker image, and we are now on node 10/12 images. 