### PR TITLE
Upgrade service-runner to v3.0.0 (node6 dropped)

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,7 +30,7 @@ function initApp(options) {
     app.conf = options.config;      // this app's config options
     app.info = packageInfo;         // this app's package info
 
-    // ensure some sane defaults
+    // ensure some reasonable defaults
     app.conf.port = app.conf.port || 8888;
     app.conf.interface = app.conf.interface || '0.0.0.0';
     // eslint-disable-next-line max-len

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"http-shutdown": "^1.2.1",
 		"js-yaml": "^3.13.1",
 		"preq": "^0.5.9",
-		"service-runner": "^2.8.4",
+		"service-runner": "^3.0.0",
 		"swagger-router": "^0.7.4",
 		"swagger-ui-dist": "^3.22.3",
 		"uuid": "^3.3.2"


### PR DESCRIPTION
As part of https://phabricator.wikimedia.org/T295398 work.