### PR TITLE
Release 0.11.0

### DIFF
--- a/lib/swagger-ui.js
+++ b/lib/swagger-ui.js
@@ -18,7 +18,7 @@ function processRequest(app, req, res) {
 
     // Disallow relative paths.
     // Test relies on docRoot ending on a slash.
-    if (filePath.substring(0, docRoot.length) !== docRoot) {
+    if (filePath.slice(0, Math.max(0, docRoot.length)) !== docRoot) {
         throw new HTTPError({
             status: 404,
             type: 'not_found',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "service-template-node",
-	"version": "0.10.0",
+	"version": "0.11.0",
 	"description": "A blueprint for MediaWiki REST API services",
 	"main": "./app.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 	"devDependencies": {
 		"ajv": "^6.5.4",
 		"chai": "^4.3.0",
-		"eslint-config-wikimedia": "0.20.0",
+		"eslint-config-wikimedia": "0.21.0",
 		"extend": "^3.0.2",
 		"mocha": "^5.2.0",
 		"mocha-lcov-reporter": "^1.3.0",

--- a/test/features/app/spec.js
+++ b/test/features/app/spec.js
@@ -51,7 +51,7 @@ function constructTestCase(title, path, method, request, response) {
     return {
         title,
         request: {
-            uri: (baseUrl || server.config.uri) + (path[0] === '/' ? path.substr(1) : path),
+            uri: (baseUrl || server.config.uri) + (path[0] === '/' ? path.slice(1) : path),
             method,
             headers: request.headers || {},
             query: request.query,


### PR DESCRIPTION
Changes since v0.10.0:
* Avoid unncessary use of ableist language (James D. Forrester)
* Update router metric to Histogram & use toggleable service label for router metric (Cole White)
* Upgrade service-runner to dev branch with new metrics api (Cole White)
* Upgrade service-runner to v2.8.0 (Clara Andrew-Wani)
* Upgrade service-runner to v2.8.3 (Kosta Harlan)
* Upgrade service-runner to v2.8.4 for prometheus label value fix (Ottomata)
* Upgrade service-runner to v3.0.0 (node6 dropped) (James D. Forrester)
* config: Replace gelf logging config (Cole White)
* blubber: Add env specific config file (nikkhn)
* blubber: Remove LINK env variable in default (Nikki Nikkhoui)

* README: Add blubber cmd examples (nikkhn)
* README: Add blurb about blubber and docker script deprecation (nikkhn)
* README: Correct documented variable name (Nikki Nikkhoui)
* README: Drop TravisCI badge (James D. Forrester)
* README: Specify phab as issue tracker (Nikki Nikkhoui)
* README: Typo fix, remove deprecated version num (nikkhn)

* build: Simplify and modernise eslint configuration (James D. Forrester)
* build: Update eslint-config-wikimedia and eslint-plugin-jsdoc doc dependency versions (Ottomata)
* build: Upgrade eslint-config-wikimedia to v0.21.0 (James D. Forrester)
