### PR TITLE
blubber: Use python and pkg-config packages; python-pkgconfig doesn't exist on bullseye

### DIFF
--- a/.pipeline/blubber.yaml
+++ b/.pipeline/blubber.yaml
@@ -9,7 +9,7 @@ variants:
   build:
     base: docker-registry.wikimedia.org/nodejs12-devel
     copies: [local]
-    apt: { packages: [git, build-essential, python-pkgconfig] }
+    apt: { packages: [git, build-essential, python, pkg-config] }
     node: { requirements: [package.json] }
   development:
     includes: [build]


### PR DESCRIPTION
Use separate python and pkg-config packages
as python-pkgconfig is not available for node 12