### PR TITLE
Propagate TraceContext headers

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -251,6 +251,12 @@ function initAndLogRequest(req, app) {
 		request: reqForLog(req, app.conf.log_header_whitelist)
 	});
 	req.context = { reqId: req.headers['x-request-id'] };
+	if ('traceparent' in req.headers) {
+		req.context.traceparent = req.headers.traceparent;
+	}
+	if ('tracestate' in req.headers) {
+		req.context.tracestate = req.headers.tracestate;
+	}
 	req.issueRequest = (request) => {
 		if (!(request.constructor === Object)) {
 			request = { uri: request };
@@ -273,6 +279,12 @@ function initAndLogRequest(req, app) {
 			'user-agent': app.conf.user_agent,
 			'x-request-id': req.context.reqId
 		});
+		if ('traceparent' in req.context) {
+			request.headers.traceparent = req.context.traceparent;
+		}
+		if ('tracestate' in req.context) {
+			request.headers.tracestate = req.context.tracestate;
+		}
 		req.logger.log('trace/req', { msg: 'Outgoing request', out_request: request });
 		return preq(request);
 	};


### PR DESCRIPTION
Similar to T225711 & a92cccea, propagate the two W3C TraceContext headers to any sub-requests made.

Propagating these two headers without modifying them or even parsing them is allowed by the W3C TraceContext Recommendation: https://www.w3.org/TR/trace-context/#design-overview

Bug: T320561